### PR TITLE
Change link text in prototype footers 

### DIFF
--- a/pay-stamp-duty-land-tax/_footer.html
+++ b/pay-stamp-duty-land-tax/_footer.html
@@ -21,7 +21,7 @@
       <br/>
       Section about paying by cheque through the post has been updated.
       {% if include.version != 4 %}
-      <br/><a href="./">View current version</a>
+      <br/><a href="./">View the most up-to-date version</a>.
       {% endif %}
       </span>
       </p>
@@ -44,9 +44,9 @@
               <span class="date"><time datetime="2016-04-01T08:00:06.000+01:00">1 April 2016</time></span><br/>
               Credit card fees have changed.
               {% if include.version != 3 %}
-              <br/><a href="./v3.2.html">View this version</a>
+              <br/><a href="./v3.2.html">View the 1 April 2016 version</a>.
               {% endif %}
-              <br/><a href="./v3.2-diff.html">Compare this version to current version</a>
+              <br/><a href="./v3.2-diff.html">See everything that’s changed on this page since 1 April 2016</a>.
             </li>
             <br>
             {% if include.version == 2 %}
@@ -58,9 +58,9 @@
               <span class="date"><time datetime="2016-02-29T09:30:12.000+00:00" class="timestamp">29 February 2016</time></span>
               Overseas payment details changed.
               {% if include.version != 2 %}
-              <br/><a href="./v2.0.html">View this version</a>
+              <br/><a href="./v2.0.html">View the 29 February 2016 version</a>.
               {% endif %}
-              <br/><a href="./v2.0-diff.html">Compare this version to current version</a>
+              <br/><a href="./v2.0-diff.html">See everything that’s changed on this page since 29 February</a>.
             </li>
           </ol>
         </div>
@@ -81,8 +81,8 @@
       <span class="date">2 December 2015</span><br/>
       First published.
       {% if include.version != 1 %}
-      <br/><a href="./view-version-1.html">View this version</a>
+      <br/><a href="./view-version-1.html">View the original version of this page</a>.
       {% endif %}
-      <br/><a href="./v1.10-diff.html">Compare this version to current version</a>
+      <br/><a href="./v1.10-diff.html">See everything that’s changed on this page since it was first published</a>.
     </p>
   </div>

--- a/rates-and-thresholds-for-employers-2017-to-2018/_footer.html
+++ b/rates-and-thresholds-for-employers-2017-to-2018/_footer.html
@@ -37,20 +37,20 @@
           <li>
             <time datetime="2017-05-30T10:28:52.000+01:00" class="timestamp">30 May 2017</time>
             Company cars: Advisory Fuel Rates (AFRs) have been updated.
-            <br/><a href="./v3.0.html">View this version</a>
-            <br/><a href="./v3.0-diff.html">Compare this version to current version</a>
+            <br/><a href="./v3.0.html">See how this page looked after it was updated on 30 May 2017</a>.
+            <br/><a href="./v3.0-diff.html">See everything that’s changed on this page since 30 May 2017</a>.
           </li>
           <li>
             <time datetime="2017-02-24T15:39:07.000+00:00" class="timestamp">24 February 2017</time>
             Scottish Income Tax rates &amp; thresholds have been updated following ratification by the Scottish Parliament.
-            <br/><a href="./v2.0.html">View this version</a>
-            <br/><a href="./v2.0-diff.html">Compare this version to current version</a>
+            <br/><a href="./v2.0.html">See how this page looked after it was updated on 24 February 2017</a>.
+            <br/><a href="./v2.0-diff.html">See everything that’s changed on this page since 24 February 2017</a>.
           </li>
           <li>
             <time datetime="2017-02-09T08:03:00.000+00:00" class="timestamp">9 February 2017</time>
             First published.
-            <br/><a href="./v1.0.html">View this version</a>
-            <br/><a href="./v1.0-diff.html">Compare this version to current version</a>
+            <br/><a href="./v1.0.html">See how this page looked when it was first published</a>.
+            <br/><a href="./v1.0-diff.html">See everything that’s changed on this page since it was first published.</a>
           </li>
          </ol>
       </div>

--- a/self-employed-national-insurance-rates/_footer.html
+++ b/self-employed-national-insurance-rates/_footer.html
@@ -27,7 +27,7 @@
 
       <p>
         Updated Class 2 and Class 4 profit threshold for 2017-18 tax year; updated Class 2 and Class 4 weekly rates for 2017-18 tax year.
-        <br/><a href="./">View current version</a>
+        <br/><a href="./">View the most up-to-date version</a>
       </p>
 
       <div class="change-notes" data-module="toggle">
@@ -44,26 +44,25 @@
               <time datetime="2016-04-06T00:00:00.000+01:00" class="timestamp">6 April 2016</time>
               <strong>12:00am</strong><br />
               Updated Class 4 bands for 2016-17 tax year: 9% band is now £8,060-43,000; 2% band is now £43,000+
-              <br/><a href="./v3.0.html">View this version</a>
-              <br/><a href="./v3.0-diff.html">Compare this version to current version</a>
+              <br/><a href="./v3.0.html">See how the page looked when this change was made</a>.
+              <br/><a href="./v3.0-diff.html">Compare with the most up-to-date version</a> - see everything that’s changed since 6 April 2016.
             </li>
             <li>
               <time datetime="2015-05-28T16:26:00.000+00:00" class="timestamp">28 May 2015</time>
               <strong>4:26pm</strong><br />
               Added self-assessment exceptions: exams professions, land and property businesses, ministers of religion, investors.
-              <br/><a href="./v2.0.html">View this version</a>
-              <br/><a href="./v2.0-diff.html">Compare this version to current version</a>
+              <br/><a href="./v2.0.html">See how the page looked when this change was made</a>.
+              <br/><a href="./v2.0-diff.html">Compare with the most up-to-date version</a> - see everything that’s changed since 28 May 2015.
             </li>
             <li>
               <time datetime="2015-04-06T00:00:00.000+00:00" class="timestamp">6 April 2015</time>
               <strong>12:00am</strong><br />
               First published.
-              <br/><a href="./v1.0.html">View this version</a>
-              <br/><a href="./v1.0-diff.html">Compare this version to current version</a>
+              <br/><a href="./v1.0.html">See how the page looked when it was first published</a>.
+              <br/><a href="./v1.0-diff.html">Compare with the most up-to-date version</a> - see everything that’s changed since the page was first published.
             </li>
           </ol>
         </div>
       </div>
     </div>
   </div>
-


### PR DESCRIPTION
I've written three variants of new link text for the prototypes. Each prototype has a different variant.

Each variant: 

+ describes what the link will do in slightly different ways
+ refers to historical versions of the page in slightly different ways

I've only changed things inside `<li>`s.
