### PR TITLE
Fixes for Historic Frontend

### DIFF
--- a/_data/pay-stamp-duty-land-tax.yml
+++ b/_data/pay-stamp-duty-land-tax.yml
@@ -25,3 +25,20 @@ past:
       First Published.
     link: ./v1.html
     diff_link: ./v1-diff.html
+versions:
+  1:
+    published: 2015-12-02
+    change_note: |
+      First Published.
+  2:
+    published: 2016-02-29
+    change_note: |
+      Overseas payment details changed.
+  3:
+    published: 2016-04-01
+    change_note: |
+      Credit card fees have changed.
+  4:
+    published: 2016-07-27
+    change_note: |
+      Section about paying by cheque through the post has been updated.

--- a/_layouts/historical-frontend.html
+++ b/_layouts/historical-frontend.html
@@ -30,24 +30,6 @@
         text-align: center;
       }
 
-      .diff { margin-bottom: 1em; }
-
-      .diff td {
-        border: 0;
-        padding: 2px 5px;
-      }
-
-      .diff .diff-line {
-        display: block;
-        border: 2px solid #ccc;
-        border-radius: 2px;
-
-      }
-
-      .diff . { padding-left: 3em }
-
-      .diff .spacer { text-align: center; font-style: italic; }
-
       .diff-line-inserted,
       .diff-line-modified.diff-line-with-inserts {
           background: #9f9;
@@ -103,7 +85,7 @@
       .diff-table td, .diff-table th { font-family: monospace; font-size: 12px; }
       .diff-table td { border: 0; padding: 0; }
 
-      .diff-checker .diff-output .diff-line {  white-space: pre-wrap; word-break: break-all; }
+      .diff-checker .diff-output .diff-line {  white-space: pre-wrap; word-break: break-all; vertical-align: top }
 
       .diff-checker .diff-table-container {
         display:flex;

--- a/_layouts/historical-frontend.html
+++ b/_layouts/historical-frontend.html
@@ -44,8 +44,6 @@
 
       }
 
-      .diff .level-1 { padding-left: 1em }
-      .diff .level-2 { padding-left: 2em }
       .diff . { padding-left: 3em }
 
       .diff .spacer { text-align: center; font-style: italic; }
@@ -132,7 +130,7 @@
       .diff-checker .diff-table-container .diff-table td.diff-line{margin:0 1px;width:50%}
       .diff-checker .diff-table-content {flex:1 1 auto}
 
-      .diff-checker, .grid-row.compare-form { margin-left: -150px; margin-right: -150px; }
+      .diff-checker, .grid-row.compare-form, .compare { margin-left: -150px; margin-right: -150px; }
 
       .diff-line-number { vertical-align: top; }
 
@@ -147,6 +145,104 @@
       .section-without-changes.visible .spacer { display: none; }
 
       strong { font-weight: bold; }
+
+      .compare-version {
+        width: 400px;
+        margin: auto;
+      }
+
+      .compare-version .next { text-align: right }
+
+      .compare-version .change-note { font-style: italic; }
+
+      .diff-checker { margin-bottom: 2em; }
+
+      .compare-version .heading-small { display: inline-block; }
+
+      .compare-choose .text {
+        display: inline-block;
+        margin: 0;
+        line-height: 1;
+        text-decoration: none;
+        color: black;
+      }
+
+      .compare-choose {
+        border: 1px solid #bfc1c3;
+        padding: 5px 7px 1px;
+        border-radius: 5px;
+        text-decoration: none;
+      }
+
+      .compare-choose-wrapper {
+        display: inline-block;
+        position: relative;
+      }
+
+      .compare-choices {
+        position: absolute;
+        right: 0;
+        width: 380px;
+        background-color: white;
+        border: 1px solid #bfc1c3;
+        border-radius: 2px;
+        box-shadow: 0 1px 3px #999;
+        display: none;
+      }
+
+      .compare {
+        margin-bottom: 1em;
+      }
+
+      .compare-choices.open {
+        display: block;
+      }
+
+      .compare-choices .choice {
+        padding: 5px 7px;
+        font-size: 80%;
+        text-decoration: none;
+        color: black;
+        display: block;
+        border-left: 4px solid transparent;
+      }
+
+      .compare-choices a.choice:hover {
+        background-color: #eee;
+      }
+
+      .compare-choices .selected {
+        border-left-color: #005ea5;
+      }
+
+      .compare-choices .disabled {
+        color: grey;
+      }
+
+      .compare-choices li {
+        border-bottom: 1px solid #bfc1c3;
+      }
+
+      .compare-choices li:last {
+        border-bottom: 0;
+      }
+
+      .compare-choices .choice .title {
+        font-weight: bold;
+        display: block;
+      }
+
+      .compare-choices .choice .change-note {
+        display: block;
+      }
+
+      .compare-choose .icon {
+        display: inline-block;
+        padding-left: 5px;
+        font-size: 70%;
+        text-decoration: none;
+        color: black;
+      }
     </style>
 
 <meta name="csrf-param" content="authenticity_token">

--- a/historical-frontend/_compare-version.html
+++ b/historical-frontend/_compare-version.html
@@ -1,0 +1,40 @@
+{% assign versions = site.data.pay-stamp-duty-land-tax.versions %}
+{% assign date_format = "%-d %b %Y" %}
+
+<h3 class="heading-small">Version {{ include.current }} - Published: {{ versions[include.current].published | date: date_format }}</h3>
+<div class="compare-choose-wrapper">
+  <a href="#" class="compare-choose">
+      <span class="text">Change</span>
+      <span class="icon">&#9660;</span>
+  </a>
+  <div class="compare-choices">
+    <ul>
+      {% for version in versions %}
+        {% capture url %}
+          {% if include.left %}
+          v{{ version[0] }}-v{{ include.other }}.html#compare
+          {% else %}
+          v{{ include.other }}-v{{ version[0] }}.html#compare
+          {% endif %}
+        {% endcapture %}
+      <li>
+        {% if version[0] == include.current %}
+          <a href="{{ url }}" class="choice selected">
+        {% elsif version[0] == include.other %}
+          <span class="choice disabled" title="Cannot compare to same version">
+        {% else %}
+          <a href="{{ url }}" class="choice">
+        {% endif %}
+          <span class="title">Version {{ version[0] }} - Published: {{ version[1].published | date: date_format }}</span>
+          <span class="change-note">{{ version[1].change_note }}</span>
+        {% if version[0] == include.other %}
+          </span>
+        {% else %}
+          </a>
+        {% endif %}
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+</div>
+<p class="change-note">{{ versions[include.current].change_note }}</p>

--- a/historical-frontend/_compare-version.html
+++ b/historical-frontend/_compare-version.html
@@ -25,7 +25,12 @@
         {% else %}
           <a href="{{ url }}" class="choice">
         {% endif %}
-          <span class="title">Version {{ version[0] }} - Published: {{ version[1].published | date: date_format }}</span>
+          <span class="title">
+            Version {{ version[0] }} - Published: {{ version[1].published | date: date_format }}
+            {% if version[0] == 4 %}
+              (Current)
+            {% endif %}
+          </span>
           <span class="change-note">{{ version[1].change_note }}</span>
         {% if version[0] == include.other %}
           </span>
@@ -37,4 +42,9 @@
     </ul>
   </div>
 </div>
+
 <p class="change-note">{{ versions[include.current].change_note }}</p>
+
+{% if include.current == 4 %}
+<p><strong>This version is currently on GOV.UK<strong></p>
+{% endif %}

--- a/historical-frontend/_compare.html
+++ b/historical-frontend/_compare.html
@@ -1,3 +1,27 @@
+<details>
+
+  <summary><span class="summary">Help comparing content</span></summary>
+
+  <div class="panel panel-border-narrow">
+
+    <p>
+      This view shows the differences between 2 versions of a piece of content.
+      You can adjust either version to change which versions of the content
+      you are comparing.
+    </p><br />
+
+    <p>
+      The content that is compared is the underlying data that is used to show
+      the page on GOV.UK. The data here is in <a href="http://yaml.org/">YAML</a>
+      format and contains <a href="https://en.wikipedia.org/wiki/HTML">HTML</a>.
+    </p><br />
+
+    <p>
+      We provide this information to provide transparency into how GOV.UK is
+      updated as part of our commitment to <a href="https://en.wikipedia.org/wiki/Open_Government_Partnership">Open Government Partnership</a>
+    </p>
+  </div>
+</details>
 
 <div class="compare" id="compare">
   <div class="title" style="text-align: center">
@@ -7,7 +31,8 @@
     <div class="column-one-half">
       <div class="compare-version">
         {% include_relative _compare-version.html current=include.from other=include.to left=true %}
-        {% if include.from > 1 and (include.from | plus: 1) == include.to %}
+        {% assign from_plus_1 = include.from | plus: 1 %}
+        {% if include.from > 1 and from_plus_1 == include.to %}
           <a href="v{{ include.from | minus: 1 }}-v{{ include.to | minus: 1 }}.html#compare">&larr; Previous Edit</a>
         {% endif %}
       </div>
@@ -16,7 +41,8 @@
     <div class="column-one-half">
       <div class="compare-version">
         {% include_relative _compare-version.html current=include.to other=include.from %}
-        {% if include.to < 4 and (include.to | minus: 1) == include.from %}
+        {% assign to_minus_1 = include.to | minus: 1 %}
+        {% if include.to < 4 and to_minus_1 == include.from %}
           <a href="v{{ include.from | plus: 1 }}-v{{ include.to | plus: 1}}.html#compare">Next Edit &rarr;</a>
         {% endif %}
       </div>

--- a/historical-frontend/_compare.html
+++ b/historical-frontend/_compare.html
@@ -1,0 +1,40 @@
+
+<div class="compare" id="compare">
+  <div class="title" style="text-align: center">
+    <h2 class="heading-medium">Comparing</h2>
+  </div>
+  <div class="grid-row">
+    <div class="column-one-half">
+      <div class="compare-version">
+        {% include_relative _compare-version.html current=include.from other=include.to left=true %}
+      </div>
+    </div>
+
+    <div class="column-one-half">
+      <div class="compare-version">
+        {% include_relative _compare-version.html current=include.to other=include.from %}
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+$(".compare-choose").on("click", function() {
+  var $compareChoices = $(this).parent().find(".compare-choices")
+
+  if ($compareChoices.hasClass("open")) {
+    $compareChoices.removeClass("open");
+  } else {
+    $compareChoices.addClass("open");
+  }
+  return false;
+});
+
+$(".choice.selected").on("click", function() {
+  $(this).closest(".compare-choices").removeClass("open");
+  return false;
+});
+$(".choice.disabled").on("click", function() {
+  alert($(this).attr("title"));
+});
+</script>

--- a/historical-frontend/_compare.html
+++ b/historical-frontend/_compare.html
@@ -7,12 +7,18 @@
     <div class="column-one-half">
       <div class="compare-version">
         {% include_relative _compare-version.html current=include.from other=include.to left=true %}
+        {% if include.from > 1 and (include.from | plus: 1) == include.to %}
+          <a href="v{{ include.from | minus: 1 }}-v{{ include.to | minus: 1 }}.html#compare">&larr; Previous Edit</a>
+        {% endif %}
       </div>
     </div>
 
     <div class="column-one-half">
       <div class="compare-version">
         {% include_relative _compare-version.html current=include.to other=include.from %}
+        {% if include.to < 4 and (include.to | minus: 1) == include.from %}
+          <a href="v{{ include.from | plus: 1 }}-v{{ include.to | plus: 1}}.html#compare">Next Edit &rarr;</a>
+        {% endif %}
       </div>
     </div>
   </div>

--- a/historical-frontend/_explanation.html
+++ b/historical-frontend/_explanation.html
@@ -1,0 +1,1 @@
+<p class="govuk-metadata">This page shows the details of what changed between two editions of a document that are rendered on GOV.UK.</p>

--- a/historical-frontend/_heading.html
+++ b/historical-frontend/_heading.html
@@ -1,6 +1,13 @@
+<div class="govuk-breadcrumbs " data-module="track-click">
+  <ol>
+    <li class="latest-version">
+      ← <a href="./">Go back to the document</a>
+    </li>
+  </ol>
+</div>
 <div class="need-heading">
   <div class="govuk-title length-average">
-    <p class="context">Content History</p>
+    <p class="context">Document History</p>
     <h1>Pay Stamp Duty Land Tax</h1>
   </div>
 </div>

--- a/historical-frontend/_heading.html
+++ b/historical-frontend/_heading.html
@@ -7,7 +7,7 @@
 </div>
 <div class="need-heading">
   <div class="govuk-title length-average">
-    <p class="context">Document History</p>
+    <p class="context">Page History</p>
     <h1>Pay Stamp Duty Land Tax</h1>
   </div>
 </div>

--- a/historical-frontend/choose.html
+++ b/historical-frontend/choose.html
@@ -5,7 +5,7 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
 
 {% include_relative _heading.html %}
 
-<h1 class="heading-medium">Choose a version to start with</h1>
+<h1 class="heading-medium">Updates</h1>
 
 <h2 class="heading-small"><a href="v4-v3.html">v4 - {{ site.data.pay-stamp-duty-land-tax.current.updated | date: "%-d %b %Y %I:%M%P" }}</a></h2>
 <p style="margin-top: 10px">{{ site.data.pay-stamp-duty-land-tax.current.change_note }}</p>

--- a/historical-frontend/choose.html
+++ b/historical-frontend/choose.html
@@ -7,15 +7,18 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
 
 <h1 class="heading-medium">Updates</h1>
 
-<h2 class="heading-small"><a href="v4-v3.html">v4 - {{ site.data.pay-stamp-duty-land-tax.current.updated | date: "%-d %b %Y %I:%M%P" }}</a></h2>
+<h2 class="heading-small">v4 - {{ site.data.pay-stamp-duty-land-tax.current.updated | date: "%-d %b %Y %I:%M%P" }}</h2>
 <p style="margin-top: 10px">{{ site.data.pay-stamp-duty-land-tax.current.change_note }}</p>
+<p><a href="v3-v4.html">See this change</a></p>
 
-<h2 class="heading-small"><a href="v3-v2.html">v3 - {{ site.data.pay-stamp-duty-land-tax.past[3].published | date: "%-d %b %Y %I:%M%P" }}</a></h2>
+<h2 class="heading-small">v3 - {{ site.data.pay-stamp-duty-land-tax.past[3].published | date: "%-d %b %Y %I:%M%P" }}</h2>
 <p style="margin-top: 10px">{{ site.data.pay-stamp-duty-land-tax.past[3].change_note }}</p>
+<p><a href="v2-v3.html">See this change</a></p>
 
-<h2 class="heading-small"><a href="v2-v1.html">v2 - {{ site.data.pay-stamp-duty-land-tax.past[2].published | date: "%-d %b %Y %I:%M%P" }}</a></h2>
+<h2 class="heading-small">v2 - {{ site.data.pay-stamp-duty-land-tax.past[2].published | date: "%-d %b %Y %I:%M%P" }}</h2>
 <p style="margin-top: 10px">{{ site.data.pay-stamp-duty-land-tax.past[2].change_note }}</p>
+<p><a href="v1-v2.html">See this change</a></p>
 
-<h2 class="heading-small"><a href="v1-v2.html">v1 - {{ site.data.pay-stamp-duty-land-tax.past[1].published | date: "%-d %b %Y %I:%M%P" }}</a></h2>
+<h2 class="heading-small">v1 - {{ site.data.pay-stamp-duty-land-tax.past[1].published | date: "%-d %b %Y %I:%M%P" }}</h2>
 <p style="margin-top: 10px">{{ site.data.pay-stamp-duty-land-tax.past[1].change_note }}</p>
 <br />

--- a/historical-frontend/v1-v2.html
+++ b/historical-frontend/v1-v2.html
@@ -6,1893 +6,1897 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
 {% include_relative _heading.html %}
 {% include_relative _select.html from="v1" to="v2" %}
 
-<div class="diff-table-container" data-reactid="41">
-  <div class="diff-table-content" data-reactid="42">
-    <table class="diff-table" data-reactid="43">
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="1."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
-          <td class="diff-line-number" data-content="1."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="2."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
-          <td class="diff-line-number" data-content="2."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="3."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
-          <td class="diff-line-number" data-content="3."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="4."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
-          <td class="diff-line-number" data-content="4."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="5."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
-          <td class="diff-line-number" data-content="5."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="6."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
-          <td class="diff-line-number" data-content="6."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="7."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> How to pay your Stamp Duty Land Tax (SDLT) and the time it takes for</span></td>
-          <td class="diff-line-number" data-content="7."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> How to pay your Stamp Duty Land Tax (SDLT) and the time it takes for</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="8."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  payment to reach HM Revenue and Customs (HMRC).</span></td>
-          <td class="diff-line-number" data-content="8."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  payment to reach HM Revenue and Customs (HMRC).</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="9."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
-          <td class="diff-line-number" data-content="9."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="10."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
-          <td class="diff-line-number" data-content="10."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="11."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="11."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="12."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="12."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="13."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="13."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="14."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="14."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="15."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="15."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="16."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="16."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="17."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="17."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="18."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="18."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="19."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="19."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="20."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="20."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="21."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="21."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="22."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="22."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="23."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="23."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="24."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="24."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="25."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="25."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="26."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="26."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="27."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="27."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="28."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="28."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="29."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="29."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="30."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="30."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="31."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="31."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="32."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="32."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="33."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="33."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="34."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="34."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="35."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="35."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="36."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="36."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="37."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="37."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="38."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="38."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="39."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="39."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="40."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="40."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="41."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="41."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="42."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="42."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="43."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="43."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="44."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="44."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="45."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="45."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="46."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="46."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="47."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="47."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="48."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="48."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="49."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="49."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="50."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="50."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="51."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="51."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="52."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-chaps-bacs"&gt;Online or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="52."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-chaps-bacs"&gt;Online or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="53."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="53."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="54."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="54."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="55."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="55."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="56."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="56."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="57."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="57."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="58."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="58."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="59."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="59."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="60."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="60."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="61."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="61."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="62."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="62."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="63."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="63."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="64."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="64."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="65."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="65."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="66."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="66."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="67."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="67."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="68."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="68."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="69."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="69."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="70."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="70."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="71."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="71."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="72."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="72."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="73."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="73."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="74."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="74."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="75."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="75."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="76."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="76."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="77."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="77."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="78."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="78."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="79."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="79."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="80."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="80."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="81."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="81."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="82."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="82."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="83."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="83."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="84."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="84."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="85."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="85."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="86."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="86."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="87."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="87."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="88."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="88."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="89."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="89."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="90."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="90."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="91."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="91."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="92."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="92."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="93."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="93."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="94."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="94."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="95."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="95."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="96."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="96."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="97."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="97."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="98."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="98."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="99."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="99."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="100."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="100."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="101."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="101."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="102."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="102."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="103."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="103."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="104."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-          <td class="diff-line-number" data-content="104."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="105."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="105."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="106."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="106."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="107."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="107."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="108."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="108."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="109."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="109."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="110."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="110."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="111."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="111."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="112."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="112."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="113."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="113."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="114."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="114."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="115."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="115."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="116."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="116."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="117."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="117."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="118."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="118."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="119."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="119."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="120."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="120."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="121."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="121."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="122."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="122."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="123."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="123."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="124."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="124."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="125."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="125."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="126."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="126."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="127."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="127."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="128."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="128."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="129."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="129."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="130."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="130."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="131."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="131."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="132."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="132."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="133."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="133."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="134."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="134."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="135."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="135."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="136."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="136."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="137."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="137."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="138."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="138."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-with-changes">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="139."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="139."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="140."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-removed">&lt;td&gt;GB05CITI08321012001020&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="140."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-inserted">&lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="141."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">          &lt;td&gt;CITIGB2L&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="141."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">          &lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="142."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-          <td class="diff-line-number" data-content="142."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="143."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="143."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="144."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="144."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="145."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="145."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="146."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="146."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="147."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="147."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="148."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="148."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="149."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="149."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-with-changes">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="150."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="150."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="151."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="151."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="152."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">Citibank N A</span></td>
-          <td class="diff-line-number" data-content="152."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">Barclays Bank Plc</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="153."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;Citigroup Centre</span></td>
-          <td class="diff-line-number" data-content="153."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;1 Churchill Place</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="154."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;Canary Wharf 33</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="155."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;Canada Square</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="156."></td>
-          <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
-          <td class="diff-line-number" data-content="154."></td>
-          <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="157."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-removed">5LB</span></td>
-          <td class="diff-line-number" data-content="155."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;United Kingdom</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="156."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-inserted">5HO</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="158."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="157."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="159."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="158."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="160."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="159."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="161."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="160."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="162."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="161."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="163."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="162."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="164."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="163."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="165."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll pay a 1.5% fee if you use a credit card. The fee isn’t refundable.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="164."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll pay a 1.5% fee if you use a credit card. The fee isn’t refundable.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="166."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="165."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="167."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="166."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="168."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You may be directed to use a &lt;a href="https://www.gov.uk/help/beta"&gt;beta&lt;/a&gt; service when you pay online. This is replacing BillPay.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="167."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You may be directed to use a &lt;a href="https://www.gov.uk/help/beta"&gt;beta&lt;/a&gt; service when you pay online. This is replacing BillPay.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="169."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="168."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="170."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="169."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="171."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="170."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="172."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="171."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="173."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="172."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="174."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="173."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="175."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="174."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="176."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="175."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="177."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to circumvent this restriction.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="176."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to circumvent this restriction.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="178."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="177."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="179."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="178."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="180."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="179."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="181."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="180."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="182."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="181."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="183."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="182."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="184."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="183."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="185."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="184."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="186."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="185."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="187."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="186."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="188."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="187."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="189."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="188."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="190."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="189."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="191."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="190."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="192."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="191."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="193."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="192."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="194."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="193."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="195."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="194."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="196."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="195."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="197."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="196."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="198."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="197."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="199."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="198."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="200."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="199."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="201."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="200."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="202."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="201."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="203."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="202."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="204."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="203."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="205."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="204."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="206."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="205."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="207."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="206."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="208."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay at the Post Office by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="207."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay at the Post Office by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="209."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="208."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="210."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="209."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="211."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="210."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="212."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="211."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="213."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="212."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="214."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="213."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="215."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="214."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="216."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="215."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="217."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="216."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="218."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="217."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="219."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="218."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="220."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="219."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="221."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="220."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="222."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="221."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="223."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="222."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="224."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="223."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="225."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="224."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="226."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="225."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="227."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="226."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="228."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="227."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="229."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="228."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="230."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="229."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="231."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="230."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="232."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your payment to:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="231."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your payment to:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="233."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="232."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="234."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="233."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="235."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="234."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="236."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
-          <td class="diff-line-number" data-content="235."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="237."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
-          <td class="diff-line-number" data-content="236."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="238."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
-          <td class="diff-line-number" data-content="237."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="239."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
-          <td class="diff-line-number" data-content="238."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="240."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
-          <td class="diff-line-number" data-content="239."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="241."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
-          <td class="diff-line-number" data-content="240."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="242."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="241."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="243."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="242."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="244."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="243."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="245."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re using the DX service send to:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="244."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re using the DX service send to:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="246."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="245."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="247."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="246."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="248."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="247."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="249."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
-          <td class="diff-line-number" data-content="248."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="250."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Rapid Data Capture Centre</span></td>
-          <td class="diff-line-number" data-content="249."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Rapid Data Capture Centre</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="251."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;DX725593</span></td>
-          <td class="diff-line-number" data-content="250."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;DX725593</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="252."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Bootle 9</span></td>
-          <td class="diff-line-number" data-content="251."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Bootle 9</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="253."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="252."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="254."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="253."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="255."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="254."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="256."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque to:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="255."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque to:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="257."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="256."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="258."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="257."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="259."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="258."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="260."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
-          <td class="diff-line-number" data-content="259."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="261."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
-          <td class="diff-line-number" data-content="260."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="262."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
-          <td class="diff-line-number" data-content="261."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="263."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="262."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="264."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="263."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="265."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="264."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="266."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="265."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="267."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="266."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="268."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="267."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="269."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="268."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="270."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="269."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="271."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="270."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="272."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="271."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="273."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="272."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="274."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="273."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="275."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
-          <td class="diff-line-number" data-content="274."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="276."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
-          <td class="diff-line-number" data-content="275."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="277."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
-          <td class="diff-line-number" data-content="276."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="278."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
-          <td class="diff-line-number" data-content="277."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="279."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
-          <td class="diff-line-number" data-content="278."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="280."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="279."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="281."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
-          <td class="diff-line-number" data-content="280."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="282."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="281."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="283."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
-          <td class="diff-line-number" data-content="282."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="284."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
-          <td class="diff-line-number" data-content="283."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="285."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
-          <td class="diff-line-number" data-content="284."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="286."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
-          <td class="diff-line-number" data-content="285."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="287."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
-          <td class="diff-line-number" data-content="286."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="288."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
-          <td class="diff-line-number" data-content="287."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="289."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
-          <td class="diff-line-number" data-content="288."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="290."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
-          <td class="diff-line-number" data-content="289."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="291."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
-          <td class="diff-line-number" data-content="290."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="292."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
-          <td class="diff-line-number" data-content="291."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="293."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
-          <td class="diff-line-number" data-content="292."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="294."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
-          <td class="diff-line-number" data-content="293."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="295."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
-          <td class="diff-line-number" data-content="294."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="296."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
-          <td class="diff-line-number" data-content="295."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="297."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
-          <td class="diff-line-number" data-content="296."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="298."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="297."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-with-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="299."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
-          <td class="diff-line-number" data-content="298."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="300."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-removed">'2015-12-02T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="299."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-inserted">'2016-02-29T09:30:12.000+00:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="301."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
-          <td class="diff-line-number" data-content="300."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="302."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
-          <td class="diff-line-number" data-content="301."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="303."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-          <td class="diff-line-number" data-content="302."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="304."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
-          <td class="diff-line-number" data-content="303."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="305."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-          <td class="diff-line-number" data-content="304."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="306."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
-          <td class="diff-line-number" data-content="305."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="307."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="306."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
-        </tr>
-      </tbody>
-    </table>
+<div class="diff-checker">
+  <div class="diff-output">
+    <div class="diff-table-container" data-reactid="41">
+      <div class="diff-table-content" data-reactid="42">
+        <table class="diff-table" data-reactid="43">
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="1."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
+              <td class="diff-line-number" data-content="1."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="2."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
+              <td class="diff-line-number" data-content="2."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="3."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
+              <td class="diff-line-number" data-content="3."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="4."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
+              <td class="diff-line-number" data-content="4."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="5."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
+              <td class="diff-line-number" data-content="5."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="6."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
+              <td class="diff-line-number" data-content="6."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="7."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> How to pay your Stamp Duty Land Tax (SDLT) and the time it takes for</span></td>
+              <td class="diff-line-number" data-content="7."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> How to pay your Stamp Duty Land Tax (SDLT) and the time it takes for</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="8."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  payment to reach HM Revenue and Customs (HMRC).</span></td>
+              <td class="diff-line-number" data-content="8."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  payment to reach HM Revenue and Customs (HMRC).</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="9."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
+              <td class="diff-line-number" data-content="9."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="10."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
+              <td class="diff-line-number" data-content="10."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="11."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="11."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="12."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="12."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="13."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="13."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="14."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="14."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="15."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="15."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="16."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="16."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="17."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="17."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="18."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="18."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="19."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="19."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="20."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="20."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="21."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="21."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="22."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="22."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="23."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="23."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="24."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="24."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="25."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="25."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="26."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="26."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="27."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="27."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="28."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="28."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="29."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="29."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="30."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="30."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="31."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="31."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="32."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="32."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="33."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="33."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="34."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="34."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="35."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="35."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="36."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="36."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="37."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="37."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="38."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="38."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="39."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="39."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="40."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="40."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="41."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="41."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="42."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="42."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="43."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="43."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="44."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="44."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="45."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="45."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="46."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="46."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="47."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="47."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="48."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="48."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="49."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="49."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="50."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="50."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="51."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="51."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="52."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-chaps-bacs"&gt;Online or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="52."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-chaps-bacs"&gt;Online or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="53."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="53."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="54."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="54."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="55."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="55."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="56."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="56."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="57."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="57."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="58."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="58."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="59."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="59."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="60."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="60."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="61."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="61."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="62."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="62."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="63."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="63."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="64."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="64."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="65."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="65."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="66."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="66."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="67."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="67."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="68."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="68."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="69."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="69."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="70."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="70."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="71."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="71."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="72."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="72."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="73."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="73."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="74."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="74."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="75."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="75."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="76."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="76."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="77."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="77."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="78."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="78."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="79."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="79."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="80."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="80."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="81."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="81."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="82."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="82."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="83."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="83."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="84."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="84."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="85."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="85."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="86."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="86."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="87."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="87."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="88."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="88."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="89."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="89."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="90."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="90."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="91."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="91."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="92."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="92."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="93."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="93."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="94."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="94."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="95."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="95."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="96."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="96."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="97."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="97."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="98."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="98."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="99."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="99."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="100."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="100."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="101."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="101."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="102."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="102."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="103."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="103."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="104."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+              <td class="diff-line-number" data-content="104."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="105."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="105."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="106."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="106."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="107."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="107."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="108."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="108."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="109."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="109."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="110."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="110."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="111."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="111."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="112."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="112."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="113."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="113."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="114."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="114."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="115."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="115."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="116."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="116."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="117."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="117."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="118."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="118."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="119."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="119."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="120."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="120."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="121."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="121."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="122."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="122."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="123."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="123."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="124."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="124."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="125."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="125."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="126."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="126."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="127."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="127."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="128."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="128."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="129."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="129."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="130."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="130."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="131."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="131."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="132."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="132."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="133."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="133."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="134."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="134."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="135."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="135."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="136."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="136."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="137."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="137."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="138."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="138."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-with-changes">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="139."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="139."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="140."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-removed">&lt;td&gt;GB05CITI08321012001020&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="140."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-inserted">&lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="141."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">          &lt;td&gt;CITIGB2L&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="141."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">          &lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="142."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+              <td class="diff-line-number" data-content="142."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="143."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="143."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="144."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="144."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="145."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="145."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="146."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="146."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="147."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="147."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="148."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="148."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="149."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="149."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-with-changes">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="150."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="150."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="151."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="151."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="152."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">Citibank N A</span></td>
+              <td class="diff-line-number" data-content="152."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">Barclays Bank Plc</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="153."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;Citigroup Centre</span></td>
+              <td class="diff-line-number" data-content="153."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;1 Churchill Place</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="154."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;Canary Wharf 33</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="155."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;Canada Square</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="156."></td>
+              <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
+              <td class="diff-line-number" data-content="154."></td>
+              <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="157."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-removed">5LB</span></td>
+              <td class="diff-line-number" data-content="155."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;United Kingdom</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="156."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-inserted">5HO</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="158."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="157."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="159."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="158."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="160."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="159."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="161."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="160."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="162."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="161."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="163."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="162."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="164."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="163."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="165."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll pay a 1.5% fee if you use a credit card. The fee isn’t refundable.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="164."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll pay a 1.5% fee if you use a credit card. The fee isn’t refundable.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="166."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="165."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="167."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="166."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="168."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You may be directed to use a &lt;a href="https://www.gov.uk/help/beta"&gt;beta&lt;/a&gt; service when you pay online. This is replacing BillPay.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="167."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You may be directed to use a &lt;a href="https://www.gov.uk/help/beta"&gt;beta&lt;/a&gt; service when you pay online. This is replacing BillPay.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="169."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="168."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="170."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="169."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="171."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="170."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="172."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="171."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="173."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="172."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="174."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="173."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="175."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="174."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="176."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="175."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="177."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to circumvent this restriction.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="176."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to circumvent this restriction.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="178."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="177."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="179."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="178."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="180."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="179."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="181."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="180."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="182."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="181."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="183."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="182."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="184."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="183."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="185."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="184."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="186."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="185."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="187."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="186."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="188."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="187."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="189."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="188."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="190."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="189."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="191."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="190."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="192."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="191."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="193."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="192."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="194."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="193."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="195."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="194."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="196."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="195."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="197."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="196."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="198."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="197."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="199."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="198."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="200."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="199."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="201."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="200."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="202."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="201."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="203."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="202."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="204."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="203."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="205."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="204."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="206."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="205."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="207."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="206."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="208."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay at the Post Office by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="207."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay at the Post Office by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="209."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="208."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="210."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="209."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="211."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="210."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="212."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="211."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="213."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="212."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="214."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="213."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="215."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="214."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="216."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="215."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="217."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="216."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="218."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="217."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="219."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="218."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="220."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="219."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="221."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="220."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="222."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="221."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="223."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="222."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="224."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="223."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="225."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="224."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="226."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="225."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="227."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="226."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="228."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="227."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="229."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="228."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="230."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="229."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="231."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="230."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="232."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your payment to:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="231."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your payment to:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="233."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="232."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="234."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="233."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="235."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="234."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="236."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
+              <td class="diff-line-number" data-content="235."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="237."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
+              <td class="diff-line-number" data-content="236."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="238."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
+              <td class="diff-line-number" data-content="237."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="239."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
+              <td class="diff-line-number" data-content="238."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="240."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
+              <td class="diff-line-number" data-content="239."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="241."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
+              <td class="diff-line-number" data-content="240."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="242."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="241."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="243."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="242."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="244."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="243."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="245."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re using the DX service send to:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="244."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re using the DX service send to:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="246."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="245."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="247."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="246."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="248."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="247."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="249."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
+              <td class="diff-line-number" data-content="248."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="250."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Rapid Data Capture Centre</span></td>
+              <td class="diff-line-number" data-content="249."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Rapid Data Capture Centre</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="251."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;DX725593</span></td>
+              <td class="diff-line-number" data-content="250."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;DX725593</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="252."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Bootle 9</span></td>
+              <td class="diff-line-number" data-content="251."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Bootle 9</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="253."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="252."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="254."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="253."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="255."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="254."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="256."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque to:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="255."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque to:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="257."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="256."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="258."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="257."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="259."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="258."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="260."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
+              <td class="diff-line-number" data-content="259."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="261."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
+              <td class="diff-line-number" data-content="260."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="262."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
+              <td class="diff-line-number" data-content="261."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="263."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="262."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="264."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="263."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="265."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="264."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="266."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="265."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="267."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="266."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="268."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="267."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="269."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="268."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="270."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="269."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="271."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="270."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="272."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="271."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="273."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="272."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="274."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="273."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="275."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
+              <td class="diff-line-number" data-content="274."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="276."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
+              <td class="diff-line-number" data-content="275."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="277."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
+              <td class="diff-line-number" data-content="276."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="278."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
+              <td class="diff-line-number" data-content="277."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="279."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
+              <td class="diff-line-number" data-content="278."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="280."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="279."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="281."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
+              <td class="diff-line-number" data-content="280."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="282."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="281."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="283."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
+              <td class="diff-line-number" data-content="282."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="284."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
+              <td class="diff-line-number" data-content="283."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="285."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
+              <td class="diff-line-number" data-content="284."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="286."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
+              <td class="diff-line-number" data-content="285."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="287."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
+              <td class="diff-line-number" data-content="286."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="288."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
+              <td class="diff-line-number" data-content="287."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="289."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
+              <td class="diff-line-number" data-content="288."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="290."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
+              <td class="diff-line-number" data-content="289."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="291."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
+              <td class="diff-line-number" data-content="290."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="292."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
+              <td class="diff-line-number" data-content="291."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="293."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
+              <td class="diff-line-number" data-content="292."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="294."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
+              <td class="diff-line-number" data-content="293."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="295."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
+              <td class="diff-line-number" data-content="294."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="296."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
+              <td class="diff-line-number" data-content="295."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="297."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
+              <td class="diff-line-number" data-content="296."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="298."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="297."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-with-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="299."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
+              <td class="diff-line-number" data-content="298."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="300."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-removed">'2015-12-02T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="299."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-inserted">'2016-02-29T09:30:12.000+00:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="301."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
+              <td class="diff-line-number" data-content="300."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="302."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
+              <td class="diff-line-number" data-content="301."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="303."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+              <td class="diff-line-number" data-content="302."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="304."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
+              <td class="diff-line-number" data-content="303."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="305."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+              <td class="diff-line-number" data-content="304."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="306."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
+              <td class="diff-line-number" data-content="305."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="307."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="306."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
 </div>

--- a/historical-frontend/v1-v2.html
+++ b/historical-frontend/v1-v2.html
@@ -4,7 +4,8 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
 ---
 
 {% include_relative _heading.html %}
-{% include_relative _select.html from="v1" to="v2" %}
+
+{% include_relative _compare.html from=1 to=2 %}
 
 <div class="diff-checker">
   <div class="diff-output">

--- a/historical-frontend/v1-v2.html
+++ b/historical-frontend/v1-v2.html
@@ -1833,9 +1833,6 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
             </tr>
           </tbody>
           <tbody class="section-with-changes">
-            <tr class="spacer">
-              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-            </tr>
             <tr class="diff-row">
               <td class="diff-line-number" data-content="299."></td>
               <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>

--- a/historical-frontend/v1-v3.html
+++ b/historical-frontend/v1-v3.html
@@ -4,7 +4,7 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
 ---
 
 {% include_relative _heading.html %}
-{% include_relative _select.html from="v1" to="v3" %}
+{% include_relative _compare.html from=1 to=3 %}
 
 <div class="diff-checker">
   <div class="diff-output">

--- a/historical-frontend/v1-v3.html
+++ b/historical-frontend/v1-v3.html
@@ -6,1897 +6,1901 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
 {% include_relative _heading.html %}
 {% include_relative _select.html from="v1" to="v3" %}
 
-<div class="diff-table-container" data-reactid="41">
-  <div class="diff-table-content" data-reactid="42">
-    <table class="diff-table" data-reactid="43">
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="1."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
-          <td class="diff-line-number" data-content="1."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="2."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
-          <td class="diff-line-number" data-content="2."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="3."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
-          <td class="diff-line-number" data-content="3."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="4."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
-          <td class="diff-line-number" data-content="4."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="5."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
-          <td class="diff-line-number" data-content="5."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="6."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
-          <td class="diff-line-number" data-content="6."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="7."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> How to pay your Stamp Duty Land Tax (SDLT) and the time it takes for</span></td>
-          <td class="diff-line-number" data-content="7."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> How to pay your Stamp Duty Land Tax (SDLT) and the time it takes for</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="8."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  payment to reach HM Revenue and Customs (HMRC).</span></td>
-          <td class="diff-line-number" data-content="8."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  payment to reach HM Revenue and Customs (HMRC).</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-context-change">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="9."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
-          <td class="diff-line-number" data-content="9."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="10."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
-          <td class="diff-line-number" data-content="10."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="11."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="11."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="12."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="12."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="13."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="13."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="14."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="14."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="15."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="15."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="16."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="16."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="17."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="17."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="18."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="18."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="19."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="19."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="20."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="20."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="21."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="21."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="22."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="22."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="23."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="23."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="24."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="24."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="25."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="25."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="26."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="26."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="27."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="27."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="28."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="28."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="29."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="29."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="30."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="30."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="31."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="31."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="32."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="32."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="33."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="33."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="34."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="34."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="35."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="35."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="36."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="36."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="37."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="37."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="38."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="38."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="39."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="39."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="40."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="40."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="41."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="41."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="42."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="42."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="43."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="43."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="44."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="44."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="45."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="45."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="46."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="46."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="47."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="47."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="48."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="48."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="49."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="49."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="50."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="50."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="51."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="51."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="52."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-chaps-bacs"&gt;Online or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="52."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-chaps-bacs"&gt;Online or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="53."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="53."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="54."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="54."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="55."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="55."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="56."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="56."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="57."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="57."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="58."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="58."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="59."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="59."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="60."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="60."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="61."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="61."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="62."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="62."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="63."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="63."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="64."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="64."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="65."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="65."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="66."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="66."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="67."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="67."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="68."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="68."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="69."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="69."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="70."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="70."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="71."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="71."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="72."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="72."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="73."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="73."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="74."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="74."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="75."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="75."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="76."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="76."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="77."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="77."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="78."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="78."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="79."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="79."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="80."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="80."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="81."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="81."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="82."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="82."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="83."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="83."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="84."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="84."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="85."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="85."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="86."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="86."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="87."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="87."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="88."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="88."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="89."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="89."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="90."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="90."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="91."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="91."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="92."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="92."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="93."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="93."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="94."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="94."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="95."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="95."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="96."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="96."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="97."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="97."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="98."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="98."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="99."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="99."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="100."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="100."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="101."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="101."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="102."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="102."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="103."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="103."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="104."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-          <td class="diff-line-number" data-content="104."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="105."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="105."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="106."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="106."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="107."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="107."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="108."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="108."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="109."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="109."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="110."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="110."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="111."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="111."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="112."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="112."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="113."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="113."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="114."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="114."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="115."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="115."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="116."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="116."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="117."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="117."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="118."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="118."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="119."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="119."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="120."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="120."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="121."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="121."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="122."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="122."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="123."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="123."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="124."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="124."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="125."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="125."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="126."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="126."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="127."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="127."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="128."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="128."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="129."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="129."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="130."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="130."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="131."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="131."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="132."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="132."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="133."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="133."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="134."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="134."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="135."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="135."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="136."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="136."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="137."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="137."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="138."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="138."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-with-changes">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="139."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="139."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="140."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-removed">&lt;td&gt;GB05CITI08321012001020&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="140."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-inserted">&lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="141."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">          &lt;td&gt;CITIGB2L&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="141."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">          &lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="142."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-          <td class="diff-line-number" data-content="142."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="143."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="143."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="144."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="144."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="145."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="145."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="146."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="146."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="147."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="147."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="148."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="148."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="149."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="149."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-with-changes">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="150."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="150."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="151."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="151."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="152."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">Citibank N A</span></td>
-          <td class="diff-line-number" data-content="152."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">Barclays Bank Plc</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="153."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;Citigroup Centre</span></td>
-          <td class="diff-line-number" data-content="153."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;1 Churchill Place</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="154."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;Canary Wharf 33</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="155."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;Canada Square</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="156."></td>
-          <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
-          <td class="diff-line-number" data-content="154."></td>
-          <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="157."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-removed">5LB</span></td>
-          <td class="diff-line-number" data-content="155."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;United Kingdom</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="156."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-inserted">5HP</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="158."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="157."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="159."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="158."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="160."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="159."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="161."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="160."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="162."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="161."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-with-changes">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="163."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="162."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="164."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="163."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="165."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">&lt;p&gt;You’ll pay a 1.5% fee if you use a credit card. The fee isn’t refundable.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="164."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">&lt;p&gt;There is a fee for credit cards.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="166."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="167."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="168."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;You may be directed to use a &lt;a href="https://www.gov.uk/help/beta"&gt;beta&lt;/a&gt; service when you pay online. This is replacing BillPay.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="169."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="170."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="165."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="171."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="166."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="172."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="167."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="173."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="168."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="174."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="169."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="175."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="170."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="176."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="171."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="177."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to circumvent this restriction.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="172."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to circumvent this restriction.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="178."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="173."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="179."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="174."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="180."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="175."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="181."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="176."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="182."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="177."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="183."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="178."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="184."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="179."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="185."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="180."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="186."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="181."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="187."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="182."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="188."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="183."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="189."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="184."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="190."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="185."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="191."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="186."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="192."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="187."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="193."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="188."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="194."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="189."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="195."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="190."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="196."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="191."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="197."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="192."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="198."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="193."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="199."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="194."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="200."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="195."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="201."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="196."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="202."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="197."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="203."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="198."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="204."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="199."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="205."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="200."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="206."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="201."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="207."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="202."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="208."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay at the Post Office by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="203."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay at the Post Office by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="209."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="204."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="210."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="205."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="211."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="206."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="212."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="207."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="213."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="208."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="214."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="209."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="215."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="210."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="216."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="211."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="217."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="212."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="218."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="213."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="219."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="214."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="220."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="215."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="221."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="216."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="222."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="217."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="223."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="218."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="224."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="219."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="225."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="220."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="226."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="221."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="227."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="222."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="228."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="223."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="229."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="224."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="230."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="225."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="231."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="226."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="232."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your payment to:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="227."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your payment to:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="233."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="228."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="234."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="229."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="235."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="230."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="236."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
-          <td class="diff-line-number" data-content="231."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="237."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
-          <td class="diff-line-number" data-content="232."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="238."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
-          <td class="diff-line-number" data-content="233."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="239."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
-          <td class="diff-line-number" data-content="234."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="240."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
-          <td class="diff-line-number" data-content="235."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="241."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
-          <td class="diff-line-number" data-content="236."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="242."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="237."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="243."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="238."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="244."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="239."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="245."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re using the DX service send to:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="240."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re using the DX service send to:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="246."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="241."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="247."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="242."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="248."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="243."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="249."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
-          <td class="diff-line-number" data-content="244."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="250."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Rapid Data Capture Centre</span></td>
-          <td class="diff-line-number" data-content="245."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Rapid Data Capture Centre</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="251."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;DX725593</span></td>
-          <td class="diff-line-number" data-content="246."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;DX725593</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="252."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Bootle 9</span></td>
-          <td class="diff-line-number" data-content="247."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Bootle 9</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="253."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="248."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="254."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="249."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="255."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="250."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="256."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque to:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="251."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque to:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="257."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="252."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="258."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="253."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="259."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="254."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="260."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
-          <td class="diff-line-number" data-content="255."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="261."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
-          <td class="diff-line-number" data-content="256."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="262."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
-          <td class="diff-line-number" data-content="257."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="263."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="258."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="264."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="259."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="265."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="260."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="266."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="261."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="267."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="262."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="268."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="263."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="269."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="264."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="270."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="265."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="271."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="266."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="272."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="267."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="273."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="268."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="274."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="269."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="275."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
-          <td class="diff-line-number" data-content="270."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="276."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
-          <td class="diff-line-number" data-content="271."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="277."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
-          <td class="diff-line-number" data-content="272."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="278."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
-          <td class="diff-line-number" data-content="273."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="279."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
-          <td class="diff-line-number" data-content="274."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="280."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="275."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="281."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
-          <td class="diff-line-number" data-content="276."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="282."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="277."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="283."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
-          <td class="diff-line-number" data-content="278."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="284."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
-          <td class="diff-line-number" data-content="279."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="285."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
-          <td class="diff-line-number" data-content="280."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="286."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
-          <td class="diff-line-number" data-content="281."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="287."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
-          <td class="diff-line-number" data-content="282."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="288."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
-          <td class="diff-line-number" data-content="283."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="289."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
-          <td class="diff-line-number" data-content="284."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="290."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
-          <td class="diff-line-number" data-content="285."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="291."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
-          <td class="diff-line-number" data-content="286."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="292."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
-          <td class="diff-line-number" data-content="287."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="293."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
-          <td class="diff-line-number" data-content="288."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="294."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
-          <td class="diff-line-number" data-content="289."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="295."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
-          <td class="diff-line-number" data-content="290."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="296."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
-          <td class="diff-line-number" data-content="291."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="297."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
-          <td class="diff-line-number" data-content="292."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="298."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="293."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-with-changes">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="299."></td>
-          <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
-          <td class="diff-line-number" data-content="294."></td>
-          <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="300."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-removed">'2015-12-02T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="295."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-inserted">'2016-04-01T08:00:06.000+01:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="301."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
-          <td class="diff-line-number" data-content="296."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="302."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
-          <td class="diff-line-number" data-content="297."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="303."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-          <td class="diff-line-number" data-content="298."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="304."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
-          <td class="diff-line-number" data-content="299."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="305."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-          <td class="diff-line-number" data-content="300."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="306."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
-          <td class="diff-line-number" data-content="301."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="307."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="302."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-        </tr>
-      </tbody>
-    </table>
+<div class="diff-checker">
+  <div class="diff-output">
+    <div class="diff-table-container" data-reactid="41">
+      <div class="diff-table-content" data-reactid="42">
+        <table class="diff-table" data-reactid="43">
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="1."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
+              <td class="diff-line-number" data-content="1."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="2."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
+              <td class="diff-line-number" data-content="2."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="3."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
+              <td class="diff-line-number" data-content="3."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="4."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
+              <td class="diff-line-number" data-content="4."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="5."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
+              <td class="diff-line-number" data-content="5."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="6."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
+              <td class="diff-line-number" data-content="6."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="7."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> How to pay your Stamp Duty Land Tax (SDLT) and the time it takes for</span></td>
+              <td class="diff-line-number" data-content="7."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> How to pay your Stamp Duty Land Tax (SDLT) and the time it takes for</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="8."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  payment to reach HM Revenue and Customs (HMRC).</span></td>
+              <td class="diff-line-number" data-content="8."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  payment to reach HM Revenue and Customs (HMRC).</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-context-change">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="9."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
+              <td class="diff-line-number" data-content="9."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="10."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
+              <td class="diff-line-number" data-content="10."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="11."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="11."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="12."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="12."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="13."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="13."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="14."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="14."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="15."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="15."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="16."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="16."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="17."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="17."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="18."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="18."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="19."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="19."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="20."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="20."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="21."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="21."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="22."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="22."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="23."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="23."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="24."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="24."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="25."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="25."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="26."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="26."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="27."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="27."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="28."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="28."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="29."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="29."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="30."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="30."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="31."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="31."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="32."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="32."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="33."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="33."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="34."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="34."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="35."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="35."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="36."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="36."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="37."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="37."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="38."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="38."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="39."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="39."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="40."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="40."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="41."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="41."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="42."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="42."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="43."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="43."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="44."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="44."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="45."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="45."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="46."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="46."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="47."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="47."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="48."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="48."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="49."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="49."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="50."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="50."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="51."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="51."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="52."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-chaps-bacs"&gt;Online or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="52."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-chaps-bacs"&gt;Online or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="53."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="53."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="54."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="54."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="55."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="55."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="56."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="56."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="57."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="57."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="58."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="58."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="59."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="59."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="60."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="60."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="61."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="61."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="62."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="62."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="63."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="63."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="64."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="64."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="65."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="65."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="66."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="66."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="67."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="67."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="68."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="68."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="69."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="69."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="70."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="70."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="71."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="71."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="72."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="72."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="73."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="73."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="74."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="74."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="75."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="75."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="76."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="76."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="77."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="77."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="78."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="78."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="79."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="79."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="80."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="80."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="81."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="81."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="82."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="82."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="83."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="83."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="84."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="84."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="85."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="85."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="86."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="86."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="87."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="87."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="88."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="88."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="89."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="89."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="90."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="90."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="91."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="91."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="92."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="92."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="93."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="93."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="94."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="94."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="95."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="95."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="96."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="96."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="97."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="97."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="98."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="98."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="99."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="99."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="100."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="100."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="101."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="101."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="102."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="102."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="103."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="103."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="104."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+              <td class="diff-line-number" data-content="104."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="105."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="105."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="106."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="106."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="107."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="107."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="108."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="108."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="109."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="109."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="110."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="110."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="111."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="111."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="112."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="112."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="113."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="113."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="114."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="114."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="115."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="115."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="116."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="116."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="117."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="117."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="118."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="118."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="119."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="119."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="120."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="120."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="121."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="121."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="122."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="122."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="123."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="123."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="124."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="124."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="125."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="125."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="126."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="126."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="127."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="127."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="128."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="128."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="129."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="129."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="130."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="130."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="131."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="131."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="132."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="132."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="133."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="133."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="134."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="134."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="135."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="135."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="136."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="136."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="137."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="137."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="138."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="138."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-with-changes">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="139."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="139."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="140."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-removed">&lt;td&gt;GB05CITI08321012001020&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="140."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-inserted">&lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="141."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">          &lt;td&gt;CITIGB2L&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="141."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">          &lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="142."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+              <td class="diff-line-number" data-content="142."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="143."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="143."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="144."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="144."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="145."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="145."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="146."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="146."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="147."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="147."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="148."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="148."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="149."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="149."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-with-changes">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="150."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="150."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="151."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="151."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="152."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">Citibank N A</span></td>
+              <td class="diff-line-number" data-content="152."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">Barclays Bank Plc</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="153."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;Citigroup Centre</span></td>
+              <td class="diff-line-number" data-content="153."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;1 Churchill Place</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="154."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;Canary Wharf 33</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="155."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;Canada Square</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="156."></td>
+              <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
+              <td class="diff-line-number" data-content="154."></td>
+              <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="157."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-removed">5LB</span></td>
+              <td class="diff-line-number" data-content="155."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;United Kingdom</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="156."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-inserted">5HP</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="158."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="157."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="159."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="158."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="160."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="159."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="161."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="160."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="162."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="161."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-with-changes">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="163."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="162."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="164."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="163."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="165."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">&lt;p&gt;You’ll pay a 1.5% fee if you use a credit card. The fee isn’t refundable.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="164."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">&lt;p&gt;There is a fee for credit cards.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="166."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="167."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="168."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;You may be directed to use a &lt;a href="https://www.gov.uk/help/beta"&gt;beta&lt;/a&gt; service when you pay online. This is replacing BillPay.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="169."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="170."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="165."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="171."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="166."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="172."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="167."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="173."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="168."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="174."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="169."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="175."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="170."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="176."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="171."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="177."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to circumvent this restriction.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="172."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to circumvent this restriction.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="178."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="173."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="179."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="174."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="180."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="175."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="181."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="176."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="182."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="177."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="183."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="178."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="184."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="179."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="185."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="180."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="186."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="181."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="187."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="182."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="188."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="183."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="189."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="184."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="190."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="185."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="191."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="186."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="192."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="187."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="193."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="188."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="194."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="189."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="195."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="190."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="196."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="191."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="197."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="192."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="198."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="193."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="199."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="194."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="200."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="195."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="201."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="196."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="202."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="197."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="203."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="198."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="204."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="199."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="205."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="200."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="206."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="201."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="207."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="202."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="208."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay at the Post Office by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="203."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay at the Post Office by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="209."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="204."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="210."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="205."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="211."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="206."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="212."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="207."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="213."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="208."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="214."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="209."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="215."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="210."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="216."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="211."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="217."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="212."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="218."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="213."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="219."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="214."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="220."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="215."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="221."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="216."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="222."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="217."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="223."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="218."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="224."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="219."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="225."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="220."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="226."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="221."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="227."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="222."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="228."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="223."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="229."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="224."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="230."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="225."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="231."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="226."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="232."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your payment to:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="227."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your payment to:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="233."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="228."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="234."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="229."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="235."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="230."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="236."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
+              <td class="diff-line-number" data-content="231."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="237."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
+              <td class="diff-line-number" data-content="232."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="238."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
+              <td class="diff-line-number" data-content="233."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="239."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
+              <td class="diff-line-number" data-content="234."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="240."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
+              <td class="diff-line-number" data-content="235."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="241."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
+              <td class="diff-line-number" data-content="236."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="242."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="237."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="243."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="238."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="244."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="239."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="245."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re using the DX service send to:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="240."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re using the DX service send to:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="246."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="241."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="247."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="242."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="248."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="243."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="249."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
+              <td class="diff-line-number" data-content="244."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="250."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Rapid Data Capture Centre</span></td>
+              <td class="diff-line-number" data-content="245."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Rapid Data Capture Centre</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="251."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;DX725593</span></td>
+              <td class="diff-line-number" data-content="246."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;DX725593</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="252."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Bootle 9</span></td>
+              <td class="diff-line-number" data-content="247."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Bootle 9</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="253."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="248."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="254."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="249."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="255."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="250."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="256."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque to:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="251."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque to:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="257."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="252."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="258."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="253."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="259."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="254."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="260."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
+              <td class="diff-line-number" data-content="255."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="261."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
+              <td class="diff-line-number" data-content="256."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="262."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
+              <td class="diff-line-number" data-content="257."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="263."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="258."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="264."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="259."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="265."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="260."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="266."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="261."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="267."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="262."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="268."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="263."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="269."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="264."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="270."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="265."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="271."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="266."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="272."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="267."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="273."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="268."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="274."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="269."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="275."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
+              <td class="diff-line-number" data-content="270."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="276."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
+              <td class="diff-line-number" data-content="271."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="277."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
+              <td class="diff-line-number" data-content="272."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="278."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
+              <td class="diff-line-number" data-content="273."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="279."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
+              <td class="diff-line-number" data-content="274."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="280."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="275."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="281."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
+              <td class="diff-line-number" data-content="276."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="282."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="277."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="283."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
+              <td class="diff-line-number" data-content="278."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="284."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
+              <td class="diff-line-number" data-content="279."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="285."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
+              <td class="diff-line-number" data-content="280."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="286."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
+              <td class="diff-line-number" data-content="281."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="287."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
+              <td class="diff-line-number" data-content="282."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="288."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
+              <td class="diff-line-number" data-content="283."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="289."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
+              <td class="diff-line-number" data-content="284."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="290."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
+              <td class="diff-line-number" data-content="285."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="291."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
+              <td class="diff-line-number" data-content="286."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="292."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
+              <td class="diff-line-number" data-content="287."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="293."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
+              <td class="diff-line-number" data-content="288."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="294."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
+              <td class="diff-line-number" data-content="289."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="295."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
+              <td class="diff-line-number" data-content="290."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="296."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
+              <td class="diff-line-number" data-content="291."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="297."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
+              <td class="diff-line-number" data-content="292."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="298."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="293."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-with-changes">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="299."></td>
+              <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
+              <td class="diff-line-number" data-content="294."></td>
+              <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="300."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-removed">'2015-12-02T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="295."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-inserted">'2016-04-01T08:00:06.000+01:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="301."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
+              <td class="diff-line-number" data-content="296."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="302."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
+              <td class="diff-line-number" data-content="297."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="303."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+              <td class="diff-line-number" data-content="298."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="304."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
+              <td class="diff-line-number" data-content="299."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="305."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+              <td class="diff-line-number" data-content="300."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="306."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
+              <td class="diff-line-number" data-content="301."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="307."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="302."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
 </div>

--- a/historical-frontend/v1-v4.html
+++ b/historical-frontend/v1-v4.html
@@ -6,1968 +6,1972 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
 {% include_relative _heading.html %}
 {% include_relative _select.html from="v1" to="v4" %}
 
-<div class="diff-table-container" data-reactid="41">
-  <div class="diff-table-content" data-reactid="42">
-    <table class="diff-table" data-reactid="43">
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="1."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
-          <td class="diff-line-number" data-content="1."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="2."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
-          <td class="diff-line-number" data-content="2."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="3."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
-          <td class="diff-line-number" data-content="3."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="4."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
-          <td class="diff-line-number" data-content="4."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="5."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
-          <td class="diff-line-number" data-content="5."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-with-changes">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="6."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
-          <td class="diff-line-number" data-content="6."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="7."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> </span><span class="diff-chunk diff-chunk-removed">How</span><span class="diff-chunk diff-chunk-equal"> to pay your Stamp Duty Land Tax (SDLT) and the time it </span><span class="diff-chunk diff-chunk-removed">takes for</span></td>
-          <td class="diff-line-number" data-content="7."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> </span><span class="diff-chunk diff-chunk-inserted">Find out how</span><span class="diff-chunk diff-chunk-equal"> to pay your Stamp Duty Land Tax (SDLT) and the time it </span><span class="diff-chunk diff-chunk-inserted">takes</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="8."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">  payment</span><span class="diff-chunk diff-chunk-equal"> to reach HM Revenue and Customs (HMRC).</span></td>
-          <td class="diff-line-number" data-content="8."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">  for payments</span><span class="diff-chunk diff-chunk-equal"> to reach HM Revenue and Customs (HMRC).</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="9."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
-          <td class="diff-line-number" data-content="9."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="10."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
-          <td class="diff-line-number" data-content="10."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="11."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="11."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="12."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="12."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="13."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a </span><span class="diff-chunk diff-chunk-equal">href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction </span><span class="diff-chunk diff-chunk-removed">Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="13."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a </span><span class="diff-chunk diff-chunk-inserted">rel="external" </span><span class="diff-chunk diff-chunk-equal">href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction </span><span class="diff-chunk diff-chunk-inserted">Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="14."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="15."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="14."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="16."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="15."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="17."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="16."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="18."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="17."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="19."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="18."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="20."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="19."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="21."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="20."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="22."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="21."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="23."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="22."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="24."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="23."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="25."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="24."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="26."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="25."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="27."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="26."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="28."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="27."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="29."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="28."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="30."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="29."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="31."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="30."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="32."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="31."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="33."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="32."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="34."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="33."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="35."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="34."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="36."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="35."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="37."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="36."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="38."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="37."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="39."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="38."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="40."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="39."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="41."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="40."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="42."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="41."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="43."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="42."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="44."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="43."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="45."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="44."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="46."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="45."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="47."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="46."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="48."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="47."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="49."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="48."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="50."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="49."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-with-changes">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="51."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="50."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="52."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-chaps-bacs"&gt;Online</span><span class="diff-chunk diff-chunk-equal"> or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="51."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-chaps-and-bacs"&gt;Online</span><span class="diff-chunk diff-chunk-equal"> or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="53."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="52."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="54."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="53."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="55."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="54."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="56."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="55."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-chaps-and-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="57."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="56."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="58."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="57."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="59."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="58."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="60."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="59."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="61."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="60."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="62."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="61."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="63."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="62."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="64."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="63."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="65."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="64."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="66."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="65."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="67."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="66."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="68."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="67."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="69."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="68."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="70."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="69."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-with-changes">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="71."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="70."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="72."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="71."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-chaps-and-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="73."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="72."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="74."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="73."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="75."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="74."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="76."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="75."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="77."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="76."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="78."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="77."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="79."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="78."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="80."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="79."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="81."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="80."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="82."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="81."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="83."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="82."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="84."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="83."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="85."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="84."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="86."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="85."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="87."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="86."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="88."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="87."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="89."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="88."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="90."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="89."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="91."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="90."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="92."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="91."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="93."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="92."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="94."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="93."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="95."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="94."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="96."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="95."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="97."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="96."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="98."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="97."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="99."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="98."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="100."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="99."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="101."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="100."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="102."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="101."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="103."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="102."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="104."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-          <td class="diff-line-number" data-content="103."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="105."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="104."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="106."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="105."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="107."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="106."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="108."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="107."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="109."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="108."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="110."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="109."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="111."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="110."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="112."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="111."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="113."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="112."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="114."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="113."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="115."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="114."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="116."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="115."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="117."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="116."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="118."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="117."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="119."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="118."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="120."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="119."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="121."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="120."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="122."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="121."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="123."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="122."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="124."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="123."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="125."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="124."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="126."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="125."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="127."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="126."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="128."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="127."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="129."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="128."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="130."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="129."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="131."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="130."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="132."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="131."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="133."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="132."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="134."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="133."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="135."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="134."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="136."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="135."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="137."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="136."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="138."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="137."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-with-changes">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="139."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="138."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="140."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-removed">&lt;td&gt;GB05CITI08321012001020&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="139."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-inserted">&lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="141."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">          &lt;td&gt;CITIGB2L&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="140."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">          &lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="142."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-          <td class="diff-line-number" data-content="141."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="143."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="142."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="144."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="143."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="145."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="144."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="146."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="145."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="147."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="146."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="148."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="147."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-with-changes">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="149."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="148."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="150."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="149."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="151."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="150."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="152."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">Citibank N A</span></td>
-          <td class="diff-line-number" data-content="151."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">Barclays Bank Plc</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="153."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;Citigroup Centre</span></td>
-          <td class="diff-line-number" data-content="152."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;1 Churchill Place</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="154."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;Canary Wharf 33</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="155."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;Canada Square</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="156."></td>
-          <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
-          <td class="diff-line-number" data-content="153."></td>
-          <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="157."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-removed">5LB</span></td>
-          <td class="diff-line-number" data-content="154."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;United Kingdom</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="155."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-inserted">5HP</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="158."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="156."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="159."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="157."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="160."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="158."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="161."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="159."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="162."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="160."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-with-changes">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="163."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="161."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="164."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="162."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="165."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">&lt;p&gt;You’ll pay a 1.5% fee if you use a credit card. The fee isn’t refundable.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="163."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">&lt;p&gt;There is a fee for credit cards.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="166."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="167."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="168."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;You may be directed to use a &lt;a href="https://www.gov.uk/help/beta"&gt;beta&lt;/a&gt; service when you pay online. This is replacing BillPay.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="169."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="170."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="164."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="171."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="165."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="172."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="166."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="173."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="167."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="174."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="168."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="175."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="169."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="176."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="170."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="177."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to </span><span class="diff-chunk diff-chunk-removed">circumvent</span><span class="diff-chunk diff-chunk-equal"> this restriction.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="171."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to </span><span class="diff-chunk diff-chunk-inserted">get around</span><span class="diff-chunk diff-chunk-equal"> this restriction.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="178."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="172."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="179."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="173."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="180."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="174."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="181."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="175."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="182."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="176."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="183."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="177."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="184."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="178."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="185."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="179."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="186."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="180."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="187."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="181."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="188."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="182."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="189."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="183."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="190."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="184."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="191."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="185."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="192."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="186."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="193."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="187."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="194."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="188."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="195."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="189."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="196."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="190."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="197."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="191."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="198."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="192."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="199."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="193."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="200."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="194."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="201."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="195."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="202."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="196."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="203."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="197."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="204."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="198."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-with-changes">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="205."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="199."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="206."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="200."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="207."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">&lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="201."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">&lt;p&gt;You can pay up to £10,000 at the Post Office without being charged using:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="208."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;You can pay at the Post Office by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="202."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="209."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="203."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="204."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">      &lt;li&gt;cheque (if accepted)&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="205."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">      &lt;li&gt;cash&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="206."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">      &lt;li&gt;debit card&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="207."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="208."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="209."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;p&gt;&lt;a rel="external" href="http://www.postoffice.co.uk/branch-finder"&gt;Contact your local Post Office branch&lt;/a&gt; to check if you can pay by cheque.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="210."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="210."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="211."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="211."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="212."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="212."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="213."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="213."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="214."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="214."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="215."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="215."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="216."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="216."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="217."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="217."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="218."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="218."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="219."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="219."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="220."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="220."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="221."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="221."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="222."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="222."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="223."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="223."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="224."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="224."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="225."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="225."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="226."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="226."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="227."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="227."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="228."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="228."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="229."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="229."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-with-changes">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="230."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="230."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="231."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="231."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="232."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return </span><span class="diff-chunk diff-chunk-removed">or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your</span><span class="diff-chunk diff-chunk-equal"> payment to:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="232."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return </span><span class="diff-chunk diff-chunk-inserted">and wish to pay by cheque at the same time, please send your return and</span><span class="diff-chunk diff-chunk-equal"> payment to:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="233."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="233."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="234."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="234."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="235."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="235."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="236."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
-          <td class="diff-line-number" data-content="236."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="237."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
-          <td class="diff-line-number" data-content="237."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="238."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
-          <td class="diff-line-number" data-content="238."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="239."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
-          <td class="diff-line-number" data-content="239."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="240."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
-          <td class="diff-line-number" data-content="240."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="241."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
-          <td class="diff-line-number" data-content="241."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="242."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="242."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-with-changes">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="243."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="243."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="244."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="244."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="245."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-removed">you’re using the DX service send to:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="245."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-inserted">you filed electronically but choose to pay by cheque, please send your payment, enclosing a payslip or quoting a &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; to avoid delay</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="246."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="247."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="248."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="249."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="250."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;Rapid Data Capture Centre</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="251."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;DX725593</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="252."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;Bootle 9</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="253."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="254."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="255."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="256."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="257."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="246."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="258."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="247."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="259."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="248."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="260."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
-          <td class="diff-line-number" data-content="249."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="261."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
-          <td class="diff-line-number" data-content="250."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="262."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
-          <td class="diff-line-number" data-content="251."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="263."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="252."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="264."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="253."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="265."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="254."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="266."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="255."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="267."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="256."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="268."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="257."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="269."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="258."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="270."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="259."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="271."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="260."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="272."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="261."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="273."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="262."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="274."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="263."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="275."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
-          <td class="diff-line-number" data-content="264."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="276."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
-          <td class="diff-line-number" data-content="265."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="277."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
-          <td class="diff-line-number" data-content="266."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="278."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
-          <td class="diff-line-number" data-content="267."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="279."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
-          <td class="diff-line-number" data-content="268."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="280."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="269."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="281."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
-          <td class="diff-line-number" data-content="270."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="282."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="271."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="283."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
-          <td class="diff-line-number" data-content="272."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="284."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
-          <td class="diff-line-number" data-content="273."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="285."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
-          <td class="diff-line-number" data-content="274."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="286."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
-          <td class="diff-line-number" data-content="275."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="287."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
-          <td class="diff-line-number" data-content="276."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="288."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
-          <td class="diff-line-number" data-content="277."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="289."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
-          <td class="diff-line-number" data-content="278."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="290."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
-          <td class="diff-line-number" data-content="279."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="291."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
-          <td class="diff-line-number" data-content="280."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="292."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
-          <td class="diff-line-number" data-content="281."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="293."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
-          <td class="diff-line-number" data-content="282."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="294."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
-          <td class="diff-line-number" data-content="283."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="295."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
-          <td class="diff-line-number" data-content="284."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="296."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
-          <td class="diff-line-number" data-content="285."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="297."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
-          <td class="diff-line-number" data-content="286."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="298."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="287."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-with-changes">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="299."></td>
-          <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
-          <td class="diff-line-number" data-content="288."></td>
-          <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="300."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-removed">'2015-12-02T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="289."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-inserted">'2016-07-27T10:49:59.000+01:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="301."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
-          <td class="diff-line-number" data-content="290."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="302."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
-          <td class="diff-line-number" data-content="291."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="303."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-          <td class="diff-line-number" data-content="292."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="304."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
-          <td class="diff-line-number" data-content="293."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="305."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-          <td class="diff-line-number" data-content="294."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="306."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
-          <td class="diff-line-number" data-content="295."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="307."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="296."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-        </tr>
-      </tbody>
-    </table>
+<div class="diff-checker">
+  <div class="diff-output">
+    <div class="diff-table-container" data-reactid="41">
+      <div class="diff-table-content" data-reactid="42">
+        <table class="diff-table" data-reactid="43">
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="1."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
+              <td class="diff-line-number" data-content="1."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="2."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
+              <td class="diff-line-number" data-content="2."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="3."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
+              <td class="diff-line-number" data-content="3."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="4."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
+              <td class="diff-line-number" data-content="4."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="5."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
+              <td class="diff-line-number" data-content="5."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-with-changes">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="6."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
+              <td class="diff-line-number" data-content="6."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="7."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> </span><span class="diff-chunk diff-chunk-removed">How</span><span class="diff-chunk diff-chunk-equal"> to pay your Stamp Duty Land Tax (SDLT) and the time it </span><span class="diff-chunk diff-chunk-removed">takes for</span></td>
+              <td class="diff-line-number" data-content="7."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> </span><span class="diff-chunk diff-chunk-inserted">Find out how</span><span class="diff-chunk diff-chunk-equal"> to pay your Stamp Duty Land Tax (SDLT) and the time it </span><span class="diff-chunk diff-chunk-inserted">takes</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="8."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">  payment</span><span class="diff-chunk diff-chunk-equal"> to reach HM Revenue and Customs (HMRC).</span></td>
+              <td class="diff-line-number" data-content="8."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">  for payments</span><span class="diff-chunk diff-chunk-equal"> to reach HM Revenue and Customs (HMRC).</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="9."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
+              <td class="diff-line-number" data-content="9."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="10."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
+              <td class="diff-line-number" data-content="10."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="11."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="11."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="12."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="12."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="13."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a </span><span class="diff-chunk diff-chunk-equal">href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction </span><span class="diff-chunk diff-chunk-removed">Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="13."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a </span><span class="diff-chunk diff-chunk-inserted">rel="external" </span><span class="diff-chunk diff-chunk-equal">href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction </span><span class="diff-chunk diff-chunk-inserted">Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="14."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="15."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="14."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="16."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="15."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="17."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="16."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="18."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="17."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="19."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="18."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="20."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="19."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="21."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="20."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="22."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="21."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="23."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="22."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="24."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="23."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="25."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="24."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="26."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="25."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="27."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="26."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="28."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="27."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="29."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="28."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="30."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="29."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="31."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="30."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="32."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="31."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="33."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="32."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="34."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="33."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="35."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="34."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="36."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="35."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="37."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="36."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="38."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="37."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="39."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="38."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="40."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="39."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="41."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="40."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="42."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="41."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="43."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="42."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="44."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="43."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="45."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="44."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="46."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="45."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="47."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="46."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="48."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="47."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="49."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="48."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="50."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="49."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-with-changes">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="51."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="50."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="52."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-chaps-bacs"&gt;Online</span><span class="diff-chunk diff-chunk-equal"> or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="51."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-chaps-and-bacs"&gt;Online</span><span class="diff-chunk diff-chunk-equal"> or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="53."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="52."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="54."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="53."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="55."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="54."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="56."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="55."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-chaps-and-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="57."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="56."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="58."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="57."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="59."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="58."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="60."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="59."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="61."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="60."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="62."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="61."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="63."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="62."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="64."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="63."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="65."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="64."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="66."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="65."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="67."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="66."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="68."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="67."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="69."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="68."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="70."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="69."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-with-changes">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="71."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="70."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="72."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="71."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-chaps-and-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="73."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="72."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="74."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="73."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="75."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="74."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="76."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="75."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="77."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="76."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="78."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="77."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="79."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="78."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="80."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="79."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="81."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="80."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="82."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="81."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="83."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="82."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="84."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="83."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="85."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="84."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="86."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="85."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="87."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="86."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="88."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="87."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="89."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="88."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="90."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="89."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="91."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="90."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="92."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="91."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="93."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="92."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="94."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="93."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="95."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="94."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="96."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="95."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="97."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="96."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="98."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="97."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="99."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="98."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="100."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="99."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="101."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="100."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="102."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="101."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="103."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="102."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="104."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+              <td class="diff-line-number" data-content="103."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="105."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="104."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="106."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="105."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="107."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="106."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="108."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="107."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="109."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="108."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="110."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="109."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="111."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="110."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="112."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="111."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="113."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="112."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="114."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="113."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="115."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="114."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="116."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="115."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="117."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="116."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="118."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="117."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="119."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="118."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="120."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="119."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="121."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="120."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="122."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="121."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="123."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="122."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="124."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="123."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="125."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="124."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="126."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="125."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="127."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="126."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="128."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="127."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="129."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="128."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="130."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="129."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="131."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="130."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="132."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="131."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="133."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="132."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="134."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="133."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="135."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="134."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="136."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="135."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="137."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="136."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="138."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="137."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-with-changes">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="139."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="138."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="140."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-removed">&lt;td&gt;GB05CITI08321012001020&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="139."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-inserted">&lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="141."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">          &lt;td&gt;CITIGB2L&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="140."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">          &lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="142."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+              <td class="diff-line-number" data-content="141."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="143."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="142."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="144."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="143."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="145."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="144."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="146."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="145."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="147."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="146."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="148."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="147."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-with-changes">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="149."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="148."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="150."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="149."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="151."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="150."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="152."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">Citibank N A</span></td>
+              <td class="diff-line-number" data-content="151."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">Barclays Bank Plc</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="153."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;Citigroup Centre</span></td>
+              <td class="diff-line-number" data-content="152."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;1 Churchill Place</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="154."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;Canary Wharf 33</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="155."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;Canada Square</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="156."></td>
+              <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
+              <td class="diff-line-number" data-content="153."></td>
+              <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="157."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-removed">5LB</span></td>
+              <td class="diff-line-number" data-content="154."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;United Kingdom</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="155."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-inserted">5HP</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="158."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="156."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="159."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="157."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="160."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="158."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="161."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="159."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="162."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="160."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-with-changes">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="163."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="161."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="164."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="162."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="165."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">&lt;p&gt;You’ll pay a 1.5% fee if you use a credit card. The fee isn’t refundable.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="163."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">&lt;p&gt;There is a fee for credit cards.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="166."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="167."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="168."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;You may be directed to use a &lt;a href="https://www.gov.uk/help/beta"&gt;beta&lt;/a&gt; service when you pay online. This is replacing BillPay.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="169."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="170."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="164."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="171."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="165."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="172."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="166."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="173."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="167."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="174."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="168."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="175."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="169."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="176."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="170."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="177."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to </span><span class="diff-chunk diff-chunk-removed">circumvent</span><span class="diff-chunk diff-chunk-equal"> this restriction.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="171."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to </span><span class="diff-chunk diff-chunk-inserted">get around</span><span class="diff-chunk diff-chunk-equal"> this restriction.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="178."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="172."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="179."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="173."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="180."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="174."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="181."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="175."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="182."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="176."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="183."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="177."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="184."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="178."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="185."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="179."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="186."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="180."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="187."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="181."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="188."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="182."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="189."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="183."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="190."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="184."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="191."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="185."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="192."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="186."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="193."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="187."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="194."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="188."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="195."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="189."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="196."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="190."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="197."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="191."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="198."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="192."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="199."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="193."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="200."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="194."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="201."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="195."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="202."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="196."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="203."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="197."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="204."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="198."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-with-changes">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="205."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="199."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="206."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="200."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="207."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">&lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="201."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">&lt;p&gt;You can pay up to £10,000 at the Post Office without being charged using:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="208."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;You can pay at the Post Office by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="202."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="209."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="203."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="204."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">      &lt;li&gt;cheque (if accepted)&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="205."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">      &lt;li&gt;cash&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="206."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">      &lt;li&gt;debit card&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="207."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="208."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="209."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;p&gt;&lt;a rel="external" href="http://www.postoffice.co.uk/branch-finder"&gt;Contact your local Post Office branch&lt;/a&gt; to check if you can pay by cheque.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="210."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="210."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="211."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="211."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="212."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="212."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="213."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="213."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="214."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="214."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="215."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="215."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="216."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="216."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="217."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="217."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="218."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="218."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="219."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="219."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="220."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="220."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="221."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="221."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="222."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="222."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="223."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="223."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="224."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="224."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="225."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="225."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="226."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="226."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="227."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="227."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="228."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="228."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="229."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="229."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-with-changes">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="230."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="230."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="231."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="231."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="232."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return </span><span class="diff-chunk diff-chunk-removed">or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your</span><span class="diff-chunk diff-chunk-equal"> payment to:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="232."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return </span><span class="diff-chunk diff-chunk-inserted">and wish to pay by cheque at the same time, please send your return and</span><span class="diff-chunk diff-chunk-equal"> payment to:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="233."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="233."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="234."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="234."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="235."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="235."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="236."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
+              <td class="diff-line-number" data-content="236."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="237."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
+              <td class="diff-line-number" data-content="237."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="238."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
+              <td class="diff-line-number" data-content="238."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="239."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
+              <td class="diff-line-number" data-content="239."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="240."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
+              <td class="diff-line-number" data-content="240."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="241."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
+              <td class="diff-line-number" data-content="241."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="242."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="242."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-with-changes">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="243."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="243."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="244."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="244."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="245."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-removed">you’re using the DX service send to:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="245."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-inserted">you filed electronically but choose to pay by cheque, please send your payment, enclosing a payslip or quoting a &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; to avoid delay</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="246."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="247."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="248."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="249."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="250."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;Rapid Data Capture Centre</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="251."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;DX725593</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="252."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;Bootle 9</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="253."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="254."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="255."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="256."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="257."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="246."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="258."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="247."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="259."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="248."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="260."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
+              <td class="diff-line-number" data-content="249."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="261."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
+              <td class="diff-line-number" data-content="250."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="262."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
+              <td class="diff-line-number" data-content="251."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="263."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="252."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="264."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="253."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="265."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="254."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="266."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="255."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="267."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="256."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="268."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="257."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="269."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="258."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="270."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="259."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="271."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="260."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="272."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="261."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="273."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="262."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="274."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="263."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="275."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
+              <td class="diff-line-number" data-content="264."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="276."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
+              <td class="diff-line-number" data-content="265."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="277."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
+              <td class="diff-line-number" data-content="266."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="278."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
+              <td class="diff-line-number" data-content="267."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="279."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
+              <td class="diff-line-number" data-content="268."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="280."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="269."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="281."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
+              <td class="diff-line-number" data-content="270."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="282."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="271."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="283."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
+              <td class="diff-line-number" data-content="272."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="284."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
+              <td class="diff-line-number" data-content="273."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="285."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
+              <td class="diff-line-number" data-content="274."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="286."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
+              <td class="diff-line-number" data-content="275."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="287."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
+              <td class="diff-line-number" data-content="276."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="288."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
+              <td class="diff-line-number" data-content="277."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="289."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
+              <td class="diff-line-number" data-content="278."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="290."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
+              <td class="diff-line-number" data-content="279."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="291."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
+              <td class="diff-line-number" data-content="280."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="292."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
+              <td class="diff-line-number" data-content="281."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="293."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
+              <td class="diff-line-number" data-content="282."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="294."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
+              <td class="diff-line-number" data-content="283."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="295."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
+              <td class="diff-line-number" data-content="284."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="296."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
+              <td class="diff-line-number" data-content="285."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="297."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
+              <td class="diff-line-number" data-content="286."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="298."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="287."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-with-changes">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="299."></td>
+              <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
+              <td class="diff-line-number" data-content="288."></td>
+              <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="300."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-removed">'2015-12-02T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="289."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-inserted">'2016-07-27T10:49:59.000+01:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="301."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
+              <td class="diff-line-number" data-content="290."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="302."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
+              <td class="diff-line-number" data-content="291."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="303."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+              <td class="diff-line-number" data-content="292."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="304."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
+              <td class="diff-line-number" data-content="293."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="305."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+              <td class="diff-line-number" data-content="294."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="306."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
+              <td class="diff-line-number" data-content="295."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="307."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="296."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
 </div>

--- a/historical-frontend/v1-v4.html
+++ b/historical-frontend/v1-v4.html
@@ -1583,7 +1583,7 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
               <td class="diff-line-number" data-content="245."></td>
               <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-removed">you’re using the DX service send to:&lt;/p&gt;</span></td>
               <td class="diff-line-number" data-content="245."></td>
-              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-inserted">you filed electronically but choose to pay by cheque, please send your payment, enclosing a payslip or quoting a &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; to avoid delay</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-inserted">you filed electronically but choose to pay by cheque, please send your payment, enclosing a payslip or quoting a &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; to avoid delay</span><span class="diff-chunk diff-chunk-equal"> to:&lt;/p&gt;</span></td>
             </tr>
             <tr class="diff-row">
               <td class="diff-line-number" data-content="246."></td>
@@ -1647,7 +1647,7 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
             </tr>
             <tr class="diff-row">
               <td class="diff-line-number" data-content="256."></td>
-              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque</span><span class="diff-chunk diff-chunk-equal"> to:&lt;/p&gt;</span></td>
               <td class="diff-line-number" data-content=""></td>
               <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
             </tr>

--- a/historical-frontend/v1-v4.html
+++ b/historical-frontend/v1-v4.html
@@ -4,7 +4,7 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
 ---
 
 {% include_relative _heading.html %}
-{% include_relative _select.html from="v1" to="v4" %}
+{% include_relative _compare.html from=1 to=4 %}
 
 <div class="diff-checker">
   <div class="diff-output">

--- a/historical-frontend/v2-v1.html
+++ b/historical-frontend/v2-v1.html
@@ -6,1883 +6,1887 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
 {% include_relative _heading.html %}
 {% include_relative _select.html from="v2" to="v1" %}
 
-<div class="diff-table-container" data-reactid="41">
-  <div class="diff-table-content" data-reactid="42">
-    <table class="diff-table" data-reactid="43">
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="1."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
-          <td class="diff-line-number" data-content="1."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="2."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
-          <td class="diff-line-number" data-content="2."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="3."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
-          <td class="diff-line-number" data-content="3."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="4."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
-          <td class="diff-line-number" data-content="4."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="5."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
-          <td class="diff-line-number" data-content="5."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="6."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
-          <td class="diff-line-number" data-content="6."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="7."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> How to pay your Stamp Duty Land Tax (SDLT) and the time it takes for</span></td>
-          <td class="diff-line-number" data-content="7."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> How to pay your Stamp Duty Land Tax (SDLT) and the time it takes for</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="8."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  payment to reach HM Revenue and Customs (HMRC).</span></td>
-          <td class="diff-line-number" data-content="8."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  payment to reach HM Revenue and Customs (HMRC).</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="9."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
-          <td class="diff-line-number" data-content="9."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="10."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
-          <td class="diff-line-number" data-content="10."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="11."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="11."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="12."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="12."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="13."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="13."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="14."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="14."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="15."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="15."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="16."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="16."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="17."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="17."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="18."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="18."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="19."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="19."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="20."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="20."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="21."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="21."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="22."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="22."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="23."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="23."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="24."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="24."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="25."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="25."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="26."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="26."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="27."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="27."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="28."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="28."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="29."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="29."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="30."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="30."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="31."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="31."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="32."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="32."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="33."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="33."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="34."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="34."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="35."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="35."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="36."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="36."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="37."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="37."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="38."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="38."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="39."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="39."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="40."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="40."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="41."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="41."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="42."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="42."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="43."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="43."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="44."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="44."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="45."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="45."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="46."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="46."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="47."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="47."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="48."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="48."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="49."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="49."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="50."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="50."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="51."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="51."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="52."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-chaps-bacs"&gt;Online or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="52."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-chaps-bacs"&gt;Online or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="53."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="53."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="54."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="54."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="55."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="55."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="56."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="56."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="57."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="57."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="58."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="58."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="59."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="59."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="60."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="60."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="61."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="61."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="62."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="62."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="63."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="63."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="64."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="64."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="65."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="65."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="66."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="66."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="67."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="67."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="68."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="68."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="69."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="69."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="70."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="70."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="71."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="71."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="72."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="72."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="73."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="73."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="74."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="74."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="75."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="75."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="76."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="76."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="77."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="77."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="78."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="78."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="79."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="79."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="80."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="80."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="81."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="81."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="82."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="82."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="83."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="83."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="84."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="84."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="85."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="85."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="86."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="86."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="87."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="87."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="88."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="88."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="89."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="89."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="90."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="90."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="91."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="91."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="92."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="92."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="93."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="93."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="94."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="94."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="95."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="95."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="96."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="96."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="97."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="97."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="98."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="98."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="99."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="99."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="100."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="100."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="101."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="101."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="102."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="102."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="103."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="103."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="104."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-          <td class="diff-line-number" data-content="104."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="105."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="105."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="106."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="106."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="107."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="107."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="108."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="108."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="109."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="109."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="110."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="110."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="111."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="111."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="112."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="112."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="113."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="113."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="114."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="114."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="115."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="115."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="116."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="116."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="117."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="117."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="118."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="118."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="119."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="119."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="120."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="120."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="121."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="121."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="122."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="122."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="123."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="123."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="124."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="124."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="125."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="125."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="126."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="126."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="127."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="127."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="128."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="128."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="129."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="129."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="130."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="130."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="131."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="131."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="132."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="132."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="133."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="133."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="134."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="134."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="135."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="135."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="136."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="136."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="137."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="137."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="138."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="138."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="139."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="139."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="140."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-removed">&lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="140."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-inserted">&lt;td&gt;GB05CITI08321012001020&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="141."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-removed">&lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="141."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-inserted">&lt;td&gt;CITIGB2L&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="142."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-          <td class="diff-line-number" data-content="142."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="143."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="143."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="144."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="144."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="145."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="145."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="146."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="146."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="147."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="147."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="148."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="148."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="149."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="149."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="150."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="150."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="151."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="151."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="152."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">Barclays Bank Plc</span></td>
-          <td class="diff-line-number" data-content="152."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">Citibank N A</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="153."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;1 Churchill Place</span></td>
-          <td class="diff-line-number" data-content="153."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;Citigroup Centre</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="154."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;Canary Wharf 33</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="155."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;Canada Square</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="154."></td>
-          <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
-          <td class="diff-line-number" data-content="156."></td>
-          <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="155."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;United Kingdom</span></td>
-          <td class="diff-line-number" data-content="157."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-inserted">5LB</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="156."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-removed">5HO</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="157."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="158."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="158."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="159."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="159."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="160."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="160."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="161."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="161."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="162."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="162."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="163."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="163."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="164."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="164."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll pay a 1.5% fee if you use a credit card. The fee isn’t refundable.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="165."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll pay a 1.5% fee if you use a credit card. The fee isn’t refundable.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="165."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="166."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="166."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="167."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="167."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You may be directed to use a &lt;a href="https://www.gov.uk/help/beta"&gt;beta&lt;/a&gt; service when you pay online. This is replacing BillPay.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="168."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You may be directed to use a &lt;a href="https://www.gov.uk/help/beta"&gt;beta&lt;/a&gt; service when you pay online. This is replacing BillPay.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="168."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="169."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="169."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="170."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="170."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="171."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="171."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="172."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="172."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="173."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="173."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="174."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="174."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="175."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="175."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="176."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="176."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to circumvent this restriction.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="177."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to circumvent this restriction.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="177."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="178."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="178."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="179."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="179."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="180."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="180."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="181."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="181."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="182."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="182."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="183."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="183."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="184."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="184."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="185."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="185."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="186."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="186."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="187."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="187."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="188."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="188."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="189."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="189."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="190."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="190."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="191."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="191."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="192."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="192."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="193."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="193."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="194."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="194."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="195."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="195."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="196."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="196."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="197."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="197."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="198."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="198."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="199."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="199."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="200."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="200."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="201."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="201."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="202."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="202."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="203."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="203."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="204."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="204."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="205."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="205."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="206."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="206."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="207."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="207."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay at the Post Office by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="208."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay at the Post Office by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="208."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="209."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="209."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="210."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="210."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="211."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="211."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="212."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="212."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="213."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="213."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="214."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="214."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="215."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="215."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="216."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="216."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="217."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="217."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="218."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="218."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="219."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="219."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="220."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="220."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="221."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="221."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="222."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="222."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="223."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="223."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="224."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="224."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="225."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="225."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="226."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="226."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="227."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="227."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="228."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="228."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="229."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="229."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="230."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="230."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="231."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="231."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your payment to:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="232."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your payment to:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="232."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="233."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="233."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="234."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="234."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="235."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="235."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
-          <td class="diff-line-number" data-content="236."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="236."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
-          <td class="diff-line-number" data-content="237."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="237."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
-          <td class="diff-line-number" data-content="238."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="238."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
-          <td class="diff-line-number" data-content="239."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="239."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
-          <td class="diff-line-number" data-content="240."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="240."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
-          <td class="diff-line-number" data-content="241."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="241."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="242."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="242."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="243."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="243."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="244."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="244."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re using the DX service send to:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="245."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re using the DX service send to:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="245."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="246."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="246."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="247."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="247."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="248."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="248."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
-          <td class="diff-line-number" data-content="249."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="249."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Rapid Data Capture Centre</span></td>
-          <td class="diff-line-number" data-content="250."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Rapid Data Capture Centre</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="250."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;DX725593</span></td>
-          <td class="diff-line-number" data-content="251."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;DX725593</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="251."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Bootle 9</span></td>
-          <td class="diff-line-number" data-content="252."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Bootle 9</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="252."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="253."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="253."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="254."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="254."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="255."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="255."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque to:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="256."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque to:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="256."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="257."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="257."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="258."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="258."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="259."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="259."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
-          <td class="diff-line-number" data-content="260."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="260."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
-          <td class="diff-line-number" data-content="261."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="261."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
-          <td class="diff-line-number" data-content="262."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="262."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="263."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="263."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="264."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="264."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="265."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="265."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="266."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="266."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="267."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="267."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="268."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="268."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="269."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="269."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="270."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="270."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="271."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="271."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="272."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="272."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="273."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="273."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="274."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="274."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
-          <td class="diff-line-number" data-content="275."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="275."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
-          <td class="diff-line-number" data-content="276."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="276."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
-          <td class="diff-line-number" data-content="277."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="277."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
-          <td class="diff-line-number" data-content="278."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="278."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
-          <td class="diff-line-number" data-content="279."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="279."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="280."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="280."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
-          <td class="diff-line-number" data-content="281."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="281."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="282."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="282."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
-          <td class="diff-line-number" data-content="283."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="283."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
-          <td class="diff-line-number" data-content="284."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="284."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
-          <td class="diff-line-number" data-content="285."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="285."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
-          <td class="diff-line-number" data-content="286."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="286."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
-          <td class="diff-line-number" data-content="287."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="287."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
-          <td class="diff-line-number" data-content="288."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="288."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
-          <td class="diff-line-number" data-content="289."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="289."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
-          <td class="diff-line-number" data-content="290."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="290."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
-          <td class="diff-line-number" data-content="291."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="291."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
-          <td class="diff-line-number" data-content="292."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="292."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
-          <td class="diff-line-number" data-content="293."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="293."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
-          <td class="diff-line-number" data-content="294."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="294."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
-          <td class="diff-line-number" data-content="295."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="295."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
-          <td class="diff-line-number" data-content="296."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="296."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
-          <td class="diff-line-number" data-content="297."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="297."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="298."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="298."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
-          <td class="diff-line-number" data-content="299."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="299."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-removed">'2016-02-29T09:30:12.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="300."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-inserted">'2015-12-02T14:31:42.000+00:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="300."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
-          <td class="diff-line-number" data-content="301."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="301."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
-          <td class="diff-line-number" data-content="302."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="302."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-          <td class="diff-line-number" data-content="303."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="303."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
-          <td class="diff-line-number" data-content="304."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="304."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-          <td class="diff-line-number" data-content="305."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="305."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
-          <td class="diff-line-number" data-content="306."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="306."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="307."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
-        </tr>
-      </tbody>
-    </table>
+<div class="diff-checker">
+  <div class="diff-output">
+    <div class="diff-table-container" data-reactid="41">
+      <div class="diff-table-content" data-reactid="42">
+        <table class="diff-table" data-reactid="43">
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="1."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
+              <td class="diff-line-number" data-content="1."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="2."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
+              <td class="diff-line-number" data-content="2."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="3."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
+              <td class="diff-line-number" data-content="3."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="4."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
+              <td class="diff-line-number" data-content="4."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="5."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
+              <td class="diff-line-number" data-content="5."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="6."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
+              <td class="diff-line-number" data-content="6."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="7."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> How to pay your Stamp Duty Land Tax (SDLT) and the time it takes for</span></td>
+              <td class="diff-line-number" data-content="7."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> How to pay your Stamp Duty Land Tax (SDLT) and the time it takes for</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="8."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  payment to reach HM Revenue and Customs (HMRC).</span></td>
+              <td class="diff-line-number" data-content="8."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  payment to reach HM Revenue and Customs (HMRC).</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="9."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
+              <td class="diff-line-number" data-content="9."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="10."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
+              <td class="diff-line-number" data-content="10."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="11."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="11."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="12."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="12."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="13."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="13."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="14."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="14."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="15."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="15."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="16."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="16."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="17."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="17."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="18."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="18."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="19."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="19."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="20."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="20."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="21."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="21."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="22."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="22."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="23."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="23."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="24."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="24."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="25."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="25."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="26."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="26."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="27."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="27."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="28."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="28."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="29."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="29."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="30."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="30."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="31."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="31."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="32."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="32."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="33."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="33."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="34."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="34."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="35."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="35."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="36."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="36."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="37."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="37."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="38."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="38."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="39."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="39."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="40."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="40."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="41."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="41."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="42."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="42."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="43."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="43."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="44."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="44."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="45."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="45."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="46."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="46."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="47."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="47."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="48."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="48."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="49."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="49."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="50."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="50."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="51."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="51."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="52."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-chaps-bacs"&gt;Online or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="52."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-chaps-bacs"&gt;Online or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="53."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="53."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="54."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="54."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="55."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="55."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="56."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="56."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="57."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="57."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="58."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="58."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="59."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="59."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="60."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="60."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="61."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="61."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="62."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="62."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="63."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="63."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="64."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="64."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="65."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="65."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="66."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="66."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="67."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="67."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="68."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="68."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="69."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="69."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="70."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="70."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="71."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="71."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="72."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="72."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="73."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="73."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="74."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="74."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="75."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="75."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="76."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="76."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="77."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="77."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="78."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="78."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="79."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="79."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="80."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="80."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="81."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="81."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="82."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="82."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="83."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="83."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="84."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="84."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="85."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="85."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="86."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="86."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="87."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="87."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="88."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="88."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="89."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="89."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="90."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="90."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="91."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="91."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="92."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="92."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="93."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="93."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="94."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="94."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="95."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="95."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="96."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="96."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="97."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="97."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="98."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="98."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="99."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="99."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="100."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="100."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="101."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="101."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="102."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="102."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="103."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="103."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="104."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+              <td class="diff-line-number" data-content="104."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="105."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="105."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="106."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="106."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="107."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="107."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="108."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="108."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="109."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="109."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="110."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="110."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="111."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="111."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="112."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="112."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="113."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="113."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="114."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="114."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="115."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="115."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="116."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="116."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="117."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="117."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="118."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="118."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="119."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="119."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="120."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="120."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="121."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="121."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="122."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="122."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="123."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="123."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="124."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="124."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="125."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="125."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="126."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="126."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="127."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="127."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="128."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="128."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="129."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="129."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="130."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="130."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="131."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="131."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="132."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="132."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="133."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="133."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="134."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="134."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="135."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="135."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="136."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="136."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="137."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="137."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="138."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="138."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="139."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="139."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="140."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-removed">&lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="140."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-inserted">&lt;td&gt;GB05CITI08321012001020&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="141."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-removed">&lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="141."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-inserted">&lt;td&gt;CITIGB2L&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="142."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+              <td class="diff-line-number" data-content="142."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="143."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="143."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="144."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="144."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="145."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="145."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="146."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="146."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="147."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="147."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="148."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="148."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="149."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="149."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="150."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="150."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="151."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="151."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="152."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">Barclays Bank Plc</span></td>
+              <td class="diff-line-number" data-content="152."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">Citibank N A</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="153."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;1 Churchill Place</span></td>
+              <td class="diff-line-number" data-content="153."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;Citigroup Centre</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="154."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;Canary Wharf 33</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="155."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;Canada Square</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="154."></td>
+              <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
+              <td class="diff-line-number" data-content="156."></td>
+              <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="155."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;United Kingdom</span></td>
+              <td class="diff-line-number" data-content="157."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-inserted">5LB</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="156."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-removed">5HO</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="157."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="158."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="158."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="159."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="159."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="160."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="160."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="161."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="161."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="162."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="162."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="163."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="163."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="164."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="164."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll pay a 1.5% fee if you use a credit card. The fee isn’t refundable.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="165."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll pay a 1.5% fee if you use a credit card. The fee isn’t refundable.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="165."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="166."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="166."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="167."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="167."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You may be directed to use a &lt;a href="https://www.gov.uk/help/beta"&gt;beta&lt;/a&gt; service when you pay online. This is replacing BillPay.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="168."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You may be directed to use a &lt;a href="https://www.gov.uk/help/beta"&gt;beta&lt;/a&gt; service when you pay online. This is replacing BillPay.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="168."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="169."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="169."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="170."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="170."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="171."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="171."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="172."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="172."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="173."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="173."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="174."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="174."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="175."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="175."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="176."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="176."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to circumvent this restriction.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="177."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to circumvent this restriction.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="177."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="178."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="178."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="179."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="179."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="180."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="180."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="181."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="181."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="182."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="182."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="183."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="183."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="184."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="184."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="185."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="185."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="186."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="186."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="187."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="187."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="188."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="188."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="189."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="189."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="190."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="190."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="191."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="191."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="192."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="192."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="193."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="193."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="194."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="194."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="195."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="195."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="196."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="196."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="197."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="197."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="198."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="198."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="199."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="199."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="200."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="200."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="201."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="201."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="202."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="202."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="203."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="203."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="204."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="204."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="205."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="205."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="206."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="206."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="207."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="207."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay at the Post Office by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="208."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay at the Post Office by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="208."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="209."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="209."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="210."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="210."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="211."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="211."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="212."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="212."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="213."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="213."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="214."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="214."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="215."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="215."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="216."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="216."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="217."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="217."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="218."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="218."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="219."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="219."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="220."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="220."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="221."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="221."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="222."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="222."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="223."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="223."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="224."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="224."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="225."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="225."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="226."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="226."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="227."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="227."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="228."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="228."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="229."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="229."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="230."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="230."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="231."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="231."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your payment to:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="232."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your payment to:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="232."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="233."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="233."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="234."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="234."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="235."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="235."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
+              <td class="diff-line-number" data-content="236."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="236."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
+              <td class="diff-line-number" data-content="237."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="237."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
+              <td class="diff-line-number" data-content="238."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="238."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
+              <td class="diff-line-number" data-content="239."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="239."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
+              <td class="diff-line-number" data-content="240."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="240."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
+              <td class="diff-line-number" data-content="241."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="241."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="242."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="242."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="243."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="243."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="244."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="244."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re using the DX service send to:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="245."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re using the DX service send to:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="245."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="246."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="246."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="247."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="247."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="248."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="248."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
+              <td class="diff-line-number" data-content="249."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="249."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Rapid Data Capture Centre</span></td>
+              <td class="diff-line-number" data-content="250."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Rapid Data Capture Centre</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="250."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;DX725593</span></td>
+              <td class="diff-line-number" data-content="251."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;DX725593</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="251."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Bootle 9</span></td>
+              <td class="diff-line-number" data-content="252."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Bootle 9</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="252."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="253."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="253."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="254."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="254."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="255."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="255."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque to:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="256."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque to:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="256."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="257."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="257."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="258."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="258."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="259."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="259."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
+              <td class="diff-line-number" data-content="260."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="260."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
+              <td class="diff-line-number" data-content="261."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="261."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
+              <td class="diff-line-number" data-content="262."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="262."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="263."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="263."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="264."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="264."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="265."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="265."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="266."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="266."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="267."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="267."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="268."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="268."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="269."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="269."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="270."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="270."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="271."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="271."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="272."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="272."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="273."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="273."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="274."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="274."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
+              <td class="diff-line-number" data-content="275."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="275."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
+              <td class="diff-line-number" data-content="276."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="276."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
+              <td class="diff-line-number" data-content="277."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="277."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
+              <td class="diff-line-number" data-content="278."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="278."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
+              <td class="diff-line-number" data-content="279."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="279."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="280."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="280."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
+              <td class="diff-line-number" data-content="281."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="281."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="282."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="282."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
+              <td class="diff-line-number" data-content="283."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="283."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
+              <td class="diff-line-number" data-content="284."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="284."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
+              <td class="diff-line-number" data-content="285."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="285."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
+              <td class="diff-line-number" data-content="286."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="286."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
+              <td class="diff-line-number" data-content="287."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="287."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
+              <td class="diff-line-number" data-content="288."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="288."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
+              <td class="diff-line-number" data-content="289."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="289."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
+              <td class="diff-line-number" data-content="290."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="290."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
+              <td class="diff-line-number" data-content="291."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="291."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
+              <td class="diff-line-number" data-content="292."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="292."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
+              <td class="diff-line-number" data-content="293."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="293."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
+              <td class="diff-line-number" data-content="294."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="294."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
+              <td class="diff-line-number" data-content="295."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="295."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
+              <td class="diff-line-number" data-content="296."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="296."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
+              <td class="diff-line-number" data-content="297."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="297."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="298."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="298."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
+              <td class="diff-line-number" data-content="299."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="299."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-removed">'2016-02-29T09:30:12.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="300."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-inserted">'2015-12-02T14:31:42.000+00:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="300."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
+              <td class="diff-line-number" data-content="301."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="301."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
+              <td class="diff-line-number" data-content="302."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="302."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+              <td class="diff-line-number" data-content="303."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="303."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
+              <td class="diff-line-number" data-content="304."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="304."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+              <td class="diff-line-number" data-content="305."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="305."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
+              <td class="diff-line-number" data-content="306."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="306."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="307."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
 </div>

--- a/historical-frontend/v2-v1.html
+++ b/historical-frontend/v2-v1.html
@@ -4,7 +4,7 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
 ---
 
 {% include_relative _heading.html %}
-{% include_relative _select.html from="v2" to="v1" %}
+{% include_relative _compare.html from=2 to=1 %}
 
 <div class="diff-checker">
   <div class="diff-output">

--- a/historical-frontend/v2-v3.html
+++ b/historical-frontend/v2-v3.html
@@ -6,1871 +6,1875 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
 {% include_relative _heading.html %}
 {% include_relative _select.html from="v2" to="v3" %}
 
-<div class="diff-table-container" data-reactid="41">
-  <div class="diff-table-content" data-reactid="42">
-    <table class="diff-table" data-reactid="43">
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="1."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
-          <td class="diff-line-number" data-content="1."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="2."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
-          <td class="diff-line-number" data-content="2."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="3."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
-          <td class="diff-line-number" data-content="3."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="4."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
-          <td class="diff-line-number" data-content="4."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="5."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
-          <td class="diff-line-number" data-content="5."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="6."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
-          <td class="diff-line-number" data-content="6."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="7."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> How to pay your Stamp Duty Land Tax (SDLT) and the time it takes for</span></td>
-          <td class="diff-line-number" data-content="7."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> How to pay your Stamp Duty Land Tax (SDLT) and the time it takes for</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="8."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  payment to reach HM Revenue and Customs (HMRC).</span></td>
-          <td class="diff-line-number" data-content="8."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  payment to reach HM Revenue and Customs (HMRC).</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="9."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
-          <td class="diff-line-number" data-content="9."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="10."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
-          <td class="diff-line-number" data-content="10."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="11."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="11."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="12."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="12."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="13."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="13."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="14."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="14."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="15."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="15."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="16."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="16."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="17."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="17."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="18."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="18."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="19."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="19."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="20."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="20."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="21."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="21."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="22."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="22."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="23."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="23."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="24."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="24."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="25."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="25."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="26."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="26."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="27."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="27."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="28."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="28."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="29."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="29."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="30."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="30."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="31."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="31."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="32."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="32."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="33."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="33."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="34."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="34."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="35."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="35."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="36."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="36."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="37."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="37."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="38."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="38."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="39."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="39."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="40."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="40."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="41."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="41."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="42."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="42."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="43."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="43."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="44."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="44."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="45."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="45."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="46."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="46."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="47."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="47."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="48."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="48."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="49."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="49."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="50."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="50."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="51."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="51."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="52."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-chaps-bacs"&gt;Online or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="52."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-chaps-bacs"&gt;Online or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="53."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="53."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="54."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="54."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="55."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="55."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="56."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="56."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="57."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="57."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="58."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="58."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="59."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="59."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="60."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="60."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="61."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="61."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="62."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="62."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="63."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="63."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="64."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="64."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="65."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="65."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="66."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="66."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="67."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="67."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="68."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="68."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="69."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="69."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="70."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="70."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="71."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="71."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="72."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="72."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="73."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="73."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="74."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="74."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="75."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="75."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="76."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="76."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="77."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="77."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="78."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="78."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="79."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="79."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="80."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="80."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="81."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="81."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="82."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="82."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="83."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="83."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="84."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="84."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="85."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="85."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="86."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="86."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="87."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="87."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="88."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="88."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="89."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="89."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="90."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="90."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="91."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="91."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="92."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="92."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="93."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="93."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="94."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="94."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="95."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="95."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="96."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="96."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="97."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="97."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="98."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="98."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="99."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="99."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="100."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="100."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="101."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="101."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="102."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="102."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="103."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="103."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="104."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-          <td class="diff-line-number" data-content="104."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="105."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="105."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="106."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="106."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="107."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="107."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="108."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="108."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="109."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="109."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="110."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="110."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="111."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="111."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="112."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="112."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="113."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="113."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="114."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="114."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="115."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="115."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="116."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="116."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="117."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="117."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="118."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="118."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="119."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="119."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="120."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="120."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="121."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="121."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="122."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="122."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="123."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="123."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="124."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="124."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="125."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="125."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="126."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="126."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="127."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="127."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="128."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="128."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="129."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="129."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="130."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="130."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="131."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="131."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="132."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="132."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="133."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="133."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="134."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="134."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="135."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="135."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="136."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="136."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="137."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="137."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="138."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="138."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="139."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="139."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="140."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="140."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="141."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="141."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="142."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-          <td class="diff-line-number" data-content="142."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="143."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="143."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="144."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="144."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="145."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="145."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="146."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="146."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="147."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="147."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="148."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="148."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="149."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="149."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="150."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="150."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="151."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="151."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="152."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    Barclays Bank Plc</span></td>
-          <td class="diff-line-number" data-content="152."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    Barclays Bank Plc</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="153."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;1 Churchill Place</span></td>
-          <td class="diff-line-number" data-content="153."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;1 Churchill Place</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="154."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
-          <td class="diff-line-number" data-content="154."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="155."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;United Kingdom</span></td>
-          <td class="diff-line-number" data-content="155."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;United Kingdom</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="156."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-removed">5HO</span></td>
-          <td class="diff-line-number" data-content="156."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-inserted">5HP</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="157."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="157."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="158."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="158."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="159."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="159."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="160."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="160."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="161."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="161."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="162."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="162."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="163."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="163."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="164."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">&lt;p&gt;You’ll pay a 1.5% fee if you use a credit card. The fee isn’t refundable.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="164."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">&lt;p&gt;There is a fee for credit cards.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="165."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="166."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="167."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;You may be directed to use a &lt;a href="https://www.gov.uk/help/beta"&gt;beta&lt;/a&gt; service when you pay online. This is replacing BillPay.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="168."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="169."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="165."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="170."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="166."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="171."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="167."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="172."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="168."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="173."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="169."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="174."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="170."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="175."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="171."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="176."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to circumvent this restriction.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="172."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to circumvent this restriction.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="177."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="173."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="178."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="174."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="179."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="175."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="180."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="176."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="181."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="177."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="182."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="178."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="183."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="179."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="184."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="180."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="185."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="181."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="186."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="182."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="187."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="183."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="188."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="184."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="189."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="185."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="190."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="186."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="191."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="187."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="192."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="188."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="193."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="189."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="194."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="190."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="195."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="191."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="196."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="192."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="197."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="193."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="198."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="194."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="199."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="195."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="200."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="196."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="201."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="197."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="202."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="198."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="203."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="199."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="204."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="200."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="205."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="201."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="206."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="202."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="207."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay at the Post Office by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="203."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay at the Post Office by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="208."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="204."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="209."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="205."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="210."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="206."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="211."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="207."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="212."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="208."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="213."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="209."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="214."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="210."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="215."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="211."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="216."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="212."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="217."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="213."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="218."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="214."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="219."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="215."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="220."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="216."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="221."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="217."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="222."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="218."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="223."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="219."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="224."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="220."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="225."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="221."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="226."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="222."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="227."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="223."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="228."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="224."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="229."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="225."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="230."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="226."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="231."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your payment to:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="227."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your payment to:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="232."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="228."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="233."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="229."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="234."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="230."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="235."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
-          <td class="diff-line-number" data-content="231."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="236."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
-          <td class="diff-line-number" data-content="232."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="237."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
-          <td class="diff-line-number" data-content="233."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="238."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
-          <td class="diff-line-number" data-content="234."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="239."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
-          <td class="diff-line-number" data-content="235."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="240."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
-          <td class="diff-line-number" data-content="236."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="241."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="237."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="242."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="238."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="243."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="239."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="244."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re using the DX service send to:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="240."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re using the DX service send to:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="245."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="241."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="246."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="242."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="247."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="243."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="248."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
-          <td class="diff-line-number" data-content="244."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="249."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Rapid Data Capture Centre</span></td>
-          <td class="diff-line-number" data-content="245."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Rapid Data Capture Centre</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="250."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;DX725593</span></td>
-          <td class="diff-line-number" data-content="246."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;DX725593</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="251."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Bootle 9</span></td>
-          <td class="diff-line-number" data-content="247."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Bootle 9</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="252."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="248."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="253."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="249."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="254."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="250."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="255."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque to:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="251."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque to:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="256."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="252."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="257."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="253."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="258."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="254."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="259."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
-          <td class="diff-line-number" data-content="255."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="260."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
-          <td class="diff-line-number" data-content="256."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="261."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
-          <td class="diff-line-number" data-content="257."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="262."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="258."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="263."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="259."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="264."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="260."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="265."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="261."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="266."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="262."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="267."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="263."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="268."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="264."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="269."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="265."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="270."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="266."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="271."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="267."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="272."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="268."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="273."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="269."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="274."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
-          <td class="diff-line-number" data-content="270."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="275."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
-          <td class="diff-line-number" data-content="271."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="276."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
-          <td class="diff-line-number" data-content="272."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="277."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
-          <td class="diff-line-number" data-content="273."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="278."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
-          <td class="diff-line-number" data-content="274."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="279."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="275."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="280."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
-          <td class="diff-line-number" data-content="276."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="281."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="277."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="282."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
-          <td class="diff-line-number" data-content="278."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="283."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
-          <td class="diff-line-number" data-content="279."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="284."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
-          <td class="diff-line-number" data-content="280."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="285."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
-          <td class="diff-line-number" data-content="281."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="286."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
-          <td class="diff-line-number" data-content="282."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="287."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
-          <td class="diff-line-number" data-content="283."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="288."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
-          <td class="diff-line-number" data-content="284."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="289."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
-          <td class="diff-line-number" data-content="285."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="290."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
-          <td class="diff-line-number" data-content="286."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="291."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
-          <td class="diff-line-number" data-content="287."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="292."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
-          <td class="diff-line-number" data-content="288."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="293."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
-          <td class="diff-line-number" data-content="289."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="294."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
-          <td class="diff-line-number" data-content="290."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="295."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
-          <td class="diff-line-number" data-content="291."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="296."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
-          <td class="diff-line-number" data-content="292."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="297."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="293."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="298."></td>
-          <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
-          <td class="diff-line-number" data-content="294."></td>
-          <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="299."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-removed">'2016-02-29T09:30:12.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="295."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-inserted">'2016-04-01T08:00:06.000+01:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="300."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
-          <td class="diff-line-number" data-content="296."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="301."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
-          <td class="diff-line-number" data-content="297."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="302."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-          <td class="diff-line-number" data-content="298."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="303."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
-          <td class="diff-line-number" data-content="299."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="304."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-          <td class="diff-line-number" data-content="300."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="305."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
-          <td class="diff-line-number" data-content="301."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="306."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="302."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-        </tr>
-      </tbody>
-    </table>
+<div class="diff-checker">
+  <div class="diff-output">
+    <div class="diff-table-container" data-reactid="41">
+      <div class="diff-table-content" data-reactid="42">
+        <table class="diff-table" data-reactid="43">
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="1."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
+              <td class="diff-line-number" data-content="1."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="2."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
+              <td class="diff-line-number" data-content="2."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="3."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
+              <td class="diff-line-number" data-content="3."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="4."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
+              <td class="diff-line-number" data-content="4."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="5."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
+              <td class="diff-line-number" data-content="5."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="6."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
+              <td class="diff-line-number" data-content="6."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="7."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> How to pay your Stamp Duty Land Tax (SDLT) and the time it takes for</span></td>
+              <td class="diff-line-number" data-content="7."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> How to pay your Stamp Duty Land Tax (SDLT) and the time it takes for</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="8."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  payment to reach HM Revenue and Customs (HMRC).</span></td>
+              <td class="diff-line-number" data-content="8."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  payment to reach HM Revenue and Customs (HMRC).</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="9."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
+              <td class="diff-line-number" data-content="9."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="10."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
+              <td class="diff-line-number" data-content="10."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="11."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="11."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="12."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="12."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="13."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="13."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="14."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="14."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="15."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="15."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="16."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="16."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="17."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="17."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="18."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="18."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="19."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="19."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="20."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="20."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="21."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="21."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="22."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="22."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="23."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="23."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="24."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="24."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="25."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="25."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="26."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="26."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="27."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="27."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="28."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="28."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="29."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="29."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="30."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="30."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="31."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="31."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="32."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="32."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="33."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="33."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="34."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="34."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="35."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="35."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="36."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="36."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="37."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="37."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="38."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="38."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="39."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="39."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="40."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="40."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="41."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="41."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="42."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="42."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="43."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="43."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="44."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="44."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="45."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="45."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="46."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="46."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="47."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="47."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="48."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="48."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="49."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="49."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="50."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="50."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="51."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="51."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="52."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-chaps-bacs"&gt;Online or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="52."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-chaps-bacs"&gt;Online or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="53."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="53."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="54."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="54."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="55."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="55."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="56."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="56."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="57."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="57."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="58."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="58."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="59."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="59."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="60."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="60."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="61."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="61."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="62."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="62."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="63."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="63."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="64."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="64."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="65."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="65."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="66."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="66."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="67."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="67."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="68."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="68."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="69."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="69."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="70."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="70."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="71."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="71."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="72."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="72."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="73."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="73."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="74."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="74."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="75."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="75."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="76."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="76."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="77."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="77."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="78."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="78."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="79."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="79."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="80."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="80."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="81."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="81."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="82."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="82."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="83."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="83."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="84."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="84."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="85."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="85."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="86."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="86."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="87."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="87."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="88."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="88."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="89."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="89."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="90."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="90."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="91."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="91."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="92."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="92."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="93."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="93."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="94."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="94."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="95."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="95."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="96."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="96."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="97."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="97."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="98."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="98."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="99."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="99."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="100."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="100."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="101."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="101."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="102."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="102."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="103."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="103."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="104."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+              <td class="diff-line-number" data-content="104."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="105."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="105."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="106."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="106."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="107."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="107."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="108."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="108."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="109."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="109."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="110."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="110."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="111."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="111."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="112."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="112."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="113."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="113."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="114."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="114."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="115."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="115."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="116."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="116."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="117."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="117."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="118."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="118."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="119."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="119."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="120."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="120."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="121."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="121."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="122."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="122."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="123."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="123."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="124."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="124."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="125."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="125."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="126."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="126."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="127."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="127."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="128."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="128."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="129."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="129."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="130."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="130."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="131."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="131."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="132."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="132."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="133."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="133."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="134."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="134."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="135."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="135."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="136."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="136."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="137."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="137."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="138."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="138."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="139."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="139."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="140."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="140."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="141."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="141."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="142."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+              <td class="diff-line-number" data-content="142."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="143."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="143."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="144."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="144."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="145."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="145."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="146."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="146."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="147."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="147."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="148."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="148."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="149."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="149."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="150."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="150."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="151."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="151."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="152."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    Barclays Bank Plc</span></td>
+              <td class="diff-line-number" data-content="152."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    Barclays Bank Plc</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="153."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;1 Churchill Place</span></td>
+              <td class="diff-line-number" data-content="153."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;1 Churchill Place</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="154."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
+              <td class="diff-line-number" data-content="154."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="155."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;United Kingdom</span></td>
+              <td class="diff-line-number" data-content="155."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;United Kingdom</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="156."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-removed">5HO</span></td>
+              <td class="diff-line-number" data-content="156."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-inserted">5HP</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="157."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="157."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="158."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="158."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="159."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="159."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="160."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="160."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="161."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="161."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="162."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="162."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="163."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="163."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="164."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">&lt;p&gt;You’ll pay a 1.5% fee if you use a credit card. The fee isn’t refundable.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="164."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">&lt;p&gt;There is a fee for credit cards.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="165."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="166."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="167."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;You may be directed to use a &lt;a href="https://www.gov.uk/help/beta"&gt;beta&lt;/a&gt; service when you pay online. This is replacing BillPay.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="168."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="169."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="165."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="170."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="166."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="171."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="167."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="172."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="168."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="173."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="169."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="174."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="170."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="175."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="171."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="176."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to circumvent this restriction.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="172."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to circumvent this restriction.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="177."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="173."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="178."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="174."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="179."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="175."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="180."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="176."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="181."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="177."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="182."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="178."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="183."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="179."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="184."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="180."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="185."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="181."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="186."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="182."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="187."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="183."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="188."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="184."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="189."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="185."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="190."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="186."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="191."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="187."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="192."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="188."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="193."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="189."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="194."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="190."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="195."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="191."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="196."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="192."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="197."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="193."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="198."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="194."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="199."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="195."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="200."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="196."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="201."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="197."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="202."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="198."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="203."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="199."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="204."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="200."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="205."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="201."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="206."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="202."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="207."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay at the Post Office by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="203."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay at the Post Office by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="208."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="204."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="209."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="205."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="210."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="206."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="211."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="207."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="212."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="208."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="213."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="209."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="214."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="210."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="215."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="211."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="216."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="212."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="217."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="213."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="218."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="214."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="219."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="215."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="220."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="216."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="221."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="217."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="222."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="218."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="223."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="219."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="224."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="220."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="225."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="221."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="226."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="222."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="227."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="223."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="228."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="224."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="229."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="225."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="230."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="226."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="231."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your payment to:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="227."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your payment to:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="232."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="228."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="233."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="229."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="234."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="230."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="235."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
+              <td class="diff-line-number" data-content="231."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="236."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
+              <td class="diff-line-number" data-content="232."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="237."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
+              <td class="diff-line-number" data-content="233."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="238."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
+              <td class="diff-line-number" data-content="234."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="239."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
+              <td class="diff-line-number" data-content="235."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="240."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
+              <td class="diff-line-number" data-content="236."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="241."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="237."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="242."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="238."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="243."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="239."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="244."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re using the DX service send to:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="240."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re using the DX service send to:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="245."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="241."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="246."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="242."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="247."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="243."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="248."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
+              <td class="diff-line-number" data-content="244."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="249."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Rapid Data Capture Centre</span></td>
+              <td class="diff-line-number" data-content="245."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Rapid Data Capture Centre</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="250."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;DX725593</span></td>
+              <td class="diff-line-number" data-content="246."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;DX725593</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="251."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Bootle 9</span></td>
+              <td class="diff-line-number" data-content="247."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Bootle 9</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="252."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="248."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="253."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="249."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="254."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="250."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="255."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque to:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="251."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque to:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="256."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="252."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="257."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="253."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="258."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="254."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="259."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
+              <td class="diff-line-number" data-content="255."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="260."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
+              <td class="diff-line-number" data-content="256."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="261."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
+              <td class="diff-line-number" data-content="257."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="262."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="258."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="263."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="259."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="264."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="260."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="265."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="261."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="266."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="262."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="267."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="263."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="268."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="264."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="269."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="265."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="270."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="266."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="271."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="267."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="272."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="268."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="273."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="269."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="274."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
+              <td class="diff-line-number" data-content="270."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="275."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
+              <td class="diff-line-number" data-content="271."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="276."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
+              <td class="diff-line-number" data-content="272."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="277."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
+              <td class="diff-line-number" data-content="273."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="278."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
+              <td class="diff-line-number" data-content="274."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="279."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="275."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="280."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
+              <td class="diff-line-number" data-content="276."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="281."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="277."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="282."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
+              <td class="diff-line-number" data-content="278."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="283."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
+              <td class="diff-line-number" data-content="279."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="284."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
+              <td class="diff-line-number" data-content="280."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="285."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
+              <td class="diff-line-number" data-content="281."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="286."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
+              <td class="diff-line-number" data-content="282."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="287."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
+              <td class="diff-line-number" data-content="283."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="288."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
+              <td class="diff-line-number" data-content="284."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="289."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
+              <td class="diff-line-number" data-content="285."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="290."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
+              <td class="diff-line-number" data-content="286."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="291."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
+              <td class="diff-line-number" data-content="287."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="292."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
+              <td class="diff-line-number" data-content="288."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="293."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
+              <td class="diff-line-number" data-content="289."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="294."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
+              <td class="diff-line-number" data-content="290."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="295."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
+              <td class="diff-line-number" data-content="291."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="296."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
+              <td class="diff-line-number" data-content="292."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="297."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="293."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="298."></td>
+              <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
+              <td class="diff-line-number" data-content="294."></td>
+              <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="299."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-removed">'2016-02-29T09:30:12.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="295."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-inserted">'2016-04-01T08:00:06.000+01:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="300."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
+              <td class="diff-line-number" data-content="296."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="301."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
+              <td class="diff-line-number" data-content="297."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="302."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+              <td class="diff-line-number" data-content="298."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="303."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
+              <td class="diff-line-number" data-content="299."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="304."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+              <td class="diff-line-number" data-content="300."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="305."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
+              <td class="diff-line-number" data-content="301."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="306."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="302."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
 </div>

--- a/historical-frontend/v2-v3.html
+++ b/historical-frontend/v2-v3.html
@@ -4,7 +4,7 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
 ---
 
 {% include_relative _heading.html %}
-{% include_relative _select.html from="v2" to="v3" %}
+{% include_relative _compare.html from=2 to=3 %}
 
 <div class="diff-checker">
   <div class="diff-output">

--- a/historical-frontend/v2-v4.html
+++ b/historical-frontend/v2-v4.html
@@ -1585,7 +1585,7 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
               <td class="diff-line-number" data-content="244."></td>
               <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-removed">you’re using the DX service send to:&lt;/p&gt;</span></td>
               <td class="diff-line-number" data-content="245."></td>
-              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-inserted">you filed electronically but choose to pay by cheque, please send your payment, enclosing a payslip or quoting a &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; to avoid delay</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-inserted">you filed electronically but choose to pay by cheque, please send your payment, enclosing a payslip or quoting a &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; to avoid delay</span><span class="diff-chunk diff-chunk-equal"> to:&lt;/p&gt;</span></td>
             </tr>
             <tr class="diff-row">
               <td class="diff-line-number" data-content="245."></td>
@@ -1649,7 +1649,7 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
             </tr>
             <tr class="diff-row">
               <td class="diff-line-number" data-content="255."></td>
-              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque</span><span class="diff-chunk diff-chunk-equal"> to:&lt;/p&gt;</span></td>
               <td class="diff-line-number" data-content=""></td>
               <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
             </tr>

--- a/historical-frontend/v2-v4.html
+++ b/historical-frontend/v2-v4.html
@@ -6,1970 +6,1974 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
 {% include_relative _heading.html %}
 {% include_relative _select.html from="v2" to="v4" %}
 
-<div class="diff-table-container" data-reactid="41">
-  <div class="diff-table-content" data-reactid="42">
-    <table class="diff-table" data-reactid="43">
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="1."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
-          <td class="diff-line-number" data-content="1."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="2."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
-          <td class="diff-line-number" data-content="2."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="3."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
-          <td class="diff-line-number" data-content="3."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="4."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
-          <td class="diff-line-number" data-content="4."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="5."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
-          <td class="diff-line-number" data-content="5."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="6."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
-          <td class="diff-line-number" data-content="6."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="7."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> </span><span class="diff-chunk diff-chunk-removed">How</span><span class="diff-chunk diff-chunk-equal"> to pay your Stamp Duty Land Tax (SDLT) and the time it </span><span class="diff-chunk diff-chunk-removed">takes for</span></td>
-          <td class="diff-line-number" data-content="7."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> </span><span class="diff-chunk diff-chunk-inserted">Find out how</span><span class="diff-chunk diff-chunk-equal"> to pay your Stamp Duty Land Tax (SDLT) and the time it </span><span class="diff-chunk diff-chunk-inserted">takes</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="8."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">  payment</span><span class="diff-chunk diff-chunk-equal"> to reach HM Revenue and Customs (HMRC).</span></td>
-          <td class="diff-line-number" data-content="8."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">  for payments</span><span class="diff-chunk diff-chunk-equal"> to reach HM Revenue and Customs (HMRC).</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="9."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
-          <td class="diff-line-number" data-content="9."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="10."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
-          <td class="diff-line-number" data-content="10."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="11."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="11."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="12."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="12."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="13."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a </span><span class="diff-chunk diff-chunk-equal">href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction </span><span class="diff-chunk diff-chunk-removed">Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="13."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a </span><span class="diff-chunk diff-chunk-inserted">rel="external" </span><span class="diff-chunk diff-chunk-equal">href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction </span><span class="diff-chunk diff-chunk-inserted">Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="14."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="15."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="14."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="16."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="15."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="17."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="16."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="18."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="17."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="19."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="18."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="20."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="19."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="21."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="20."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="22."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="21."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="23."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="22."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="24."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="23."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="25."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="24."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="26."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="25."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="27."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="26."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="28."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="27."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="29."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="28."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="30."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="29."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="31."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="30."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="32."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="31."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="33."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="32."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="34."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="33."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="35."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="34."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="36."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="35."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="37."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="36."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="38."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="37."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="39."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="38."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="40."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="39."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="41."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="40."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="42."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="41."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="43."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="42."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="44."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="43."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="45."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="44."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="46."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="45."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="47."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="46."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="48."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="47."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="49."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="48."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="50."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="49."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="51."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="50."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="52."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-chaps-bacs"&gt;Online</span><span class="diff-chunk diff-chunk-equal"> or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="51."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-chaps-and-bacs"&gt;Online</span><span class="diff-chunk diff-chunk-equal"> or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="53."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="52."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="54."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="53."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="55."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="54."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="56."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="55."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-chaps-and-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="57."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="56."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="58."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="57."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="59."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="58."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="60."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="59."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="61."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="60."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="62."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="61."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="63."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="62."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="64."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="63."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="65."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="64."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="66."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="65."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="67."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="66."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="68."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="67."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="69."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="68."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="70."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="69."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="71."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="70."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="72."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="71."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-chaps-and-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="73."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="72."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="74."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="73."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="75."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="74."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="76."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="75."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="77."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="76."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="78."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="77."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="79."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="78."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="80."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="79."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="81."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="80."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="82."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="81."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="83."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="82."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="84."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="83."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="85."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="84."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="86."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="85."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="87."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="86."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="88."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="87."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="89."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="88."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="90."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="89."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="91."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="90."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="92."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="91."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="93."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="92."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="94."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="93."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="95."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="94."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="96."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="95."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="97."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="96."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="98."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="97."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="99."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="98."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="100."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="99."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="101."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="100."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="102."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="101."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="103."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="102."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="104."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-          <td class="diff-line-number" data-content="103."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="105."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="104."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="106."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="105."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="107."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="106."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="108."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="107."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="109."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="108."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="110."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="109."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="111."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="110."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="112."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="111."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="113."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="112."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="114."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="113."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="115."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="114."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="116."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="115."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="117."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="116."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="118."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="117."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="119."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="118."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="120."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="119."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="121."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="120."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="122."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="121."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="123."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="122."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="124."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="123."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="125."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="124."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="126."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="125."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="127."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="126."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="128."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="127."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="129."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="128."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="130."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="129."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="131."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="130."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="132."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="131."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="133."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="132."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="134."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="133."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="135."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="134."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="136."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="135."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="137."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="136."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="138."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="137."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="139."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="138."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="140."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="139."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="141."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="140."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="142."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-          <td class="diff-line-number" data-content="141."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="143."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="142."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="144."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="143."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="145."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="144."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="146."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="145."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="147."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="146."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="148."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="147."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="149."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="148."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="150."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="149."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="151."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="150."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="152."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    Barclays Bank Plc</span></td>
-          <td class="diff-line-number" data-content="151."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    Barclays Bank Plc</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="153."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;1 Churchill Place</span></td>
-          <td class="diff-line-number" data-content="152."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;1 Churchill Place</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="154."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
-          <td class="diff-line-number" data-content="153."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="155."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;United Kingdom</span></td>
-          <td class="diff-line-number" data-content="154."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;United Kingdom</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="156."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-removed">5HO</span></td>
-          <td class="diff-line-number" data-content="155."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-inserted">5HP</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="157."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="156."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="158."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="157."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="159."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="158."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="160."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="159."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="161."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="160."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="162."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="161."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="163."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="162."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="164."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">&lt;p&gt;You’ll pay a 1.5% fee if you use a credit card. The fee isn’t refundable.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="163."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">&lt;p&gt;There is a fee for credit cards.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="165."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="166."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="167."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;You may be directed to use a &lt;a href="https://www.gov.uk/help/beta"&gt;beta&lt;/a&gt; service when you pay online. This is replacing BillPay.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="168."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="169."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="164."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="170."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="165."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="171."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="166."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="172."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="167."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="173."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="168."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="174."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="169."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="175."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="170."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="176."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to </span><span class="diff-chunk diff-chunk-removed">circumvent</span><span class="diff-chunk diff-chunk-equal"> this restriction.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="171."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to </span><span class="diff-chunk diff-chunk-inserted">get around</span><span class="diff-chunk diff-chunk-equal"> this restriction.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="177."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="172."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="178."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="173."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="179."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="174."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="180."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="175."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="181."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="176."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="182."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="177."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="183."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="178."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="184."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="179."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="185."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="180."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="186."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="181."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="187."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="182."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="188."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="183."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="189."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="184."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="190."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="185."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="191."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="186."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="192."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="187."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="193."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="188."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="194."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="189."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="195."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="190."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="196."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="191."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="197."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="192."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="198."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="193."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="199."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="194."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="200."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="195."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="201."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="196."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="202."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="197."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="203."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="198."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="204."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="199."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="205."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="200."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="206."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">&lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="201."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">&lt;p&gt;You can pay up to £10,000 at the Post Office without being charged using:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="207."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;You can pay at the Post Office by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="202."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="208."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="203."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="204."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">      &lt;li&gt;cheque (if accepted)&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="205."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">      &lt;li&gt;cash&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="206."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">      &lt;li&gt;debit card&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="207."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="208."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="209."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;p&gt;&lt;a rel="external" href="http://www.postoffice.co.uk/branch-finder"&gt;Contact your local Post Office branch&lt;/a&gt; to check if you can pay by cheque.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="209."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="210."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="210."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="211."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="211."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="212."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="212."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="213."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="213."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="214."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="214."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="215."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="215."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="216."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="216."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="217."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="217."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="218."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="218."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="219."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="219."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="220."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="220."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="221."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="221."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="222."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="222."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="223."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="223."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="224."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="224."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="225."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="225."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="226."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="226."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="227."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="227."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="228."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="228."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="229."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="229."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="230."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="230."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="231."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="231."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return </span><span class="diff-chunk diff-chunk-removed">or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your</span><span class="diff-chunk diff-chunk-equal"> payment to:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="232."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return </span><span class="diff-chunk diff-chunk-inserted">and wish to pay by cheque at the same time, please send your return and</span><span class="diff-chunk diff-chunk-equal"> payment to:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="232."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="233."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="233."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="234."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="234."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="235."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="235."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
-          <td class="diff-line-number" data-content="236."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="236."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
-          <td class="diff-line-number" data-content="237."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="237."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
-          <td class="diff-line-number" data-content="238."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="238."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
-          <td class="diff-line-number" data-content="239."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="239."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
-          <td class="diff-line-number" data-content="240."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="240."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
-          <td class="diff-line-number" data-content="241."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="241."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="242."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="242."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="243."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="243."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="244."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="244."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-removed">you’re using the DX service send to:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="245."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-inserted">you filed electronically but choose to pay by cheque, please send your payment, enclosing a payslip or quoting a &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; to avoid delay</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="245."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="246."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="247."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="248."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="249."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;Rapid Data Capture Centre</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="250."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;DX725593</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="251."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;Bootle 9</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="252."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="253."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="254."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="255."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="256."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="246."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="257."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="247."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="258."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="248."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="259."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
-          <td class="diff-line-number" data-content="249."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="260."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
-          <td class="diff-line-number" data-content="250."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="261."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
-          <td class="diff-line-number" data-content="251."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="262."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="252."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="263."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="253."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="264."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="254."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="265."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="255."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="266."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="256."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="267."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="257."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="268."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="258."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="269."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="259."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="270."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="260."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="271."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="261."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="272."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="262."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="273."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="263."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="274."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
-          <td class="diff-line-number" data-content="264."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="275."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
-          <td class="diff-line-number" data-content="265."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="276."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
-          <td class="diff-line-number" data-content="266."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="277."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
-          <td class="diff-line-number" data-content="267."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="278."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
-          <td class="diff-line-number" data-content="268."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="279."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="269."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="280."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
-          <td class="diff-line-number" data-content="270."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="281."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="271."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="282."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
-          <td class="diff-line-number" data-content="272."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="283."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
-          <td class="diff-line-number" data-content="273."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="284."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
-          <td class="diff-line-number" data-content="274."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="285."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
-          <td class="diff-line-number" data-content="275."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="286."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
-          <td class="diff-line-number" data-content="276."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="287."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
-          <td class="diff-line-number" data-content="277."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="288."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
-          <td class="diff-line-number" data-content="278."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="289."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
-          <td class="diff-line-number" data-content="279."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="290."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
-          <td class="diff-line-number" data-content="280."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="291."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
-          <td class="diff-line-number" data-content="281."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="292."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
-          <td class="diff-line-number" data-content="282."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="293."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
-          <td class="diff-line-number" data-content="283."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="294."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
-          <td class="diff-line-number" data-content="284."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="295."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
-          <td class="diff-line-number" data-content="285."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="296."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
-          <td class="diff-line-number" data-content="286."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="297."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="287."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="298."></td>
-          <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
-          <td class="diff-line-number" data-content="288."></td>
-          <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="299."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-removed">'2016-02-29T09:30:12.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="289."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-inserted">'2016-07-27T10:49:59.000+01:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="300."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
-          <td class="diff-line-number" data-content="290."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="301."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
-          <td class="diff-line-number" data-content="291."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="302."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-          <td class="diff-line-number" data-content="292."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="303."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
-          <td class="diff-line-number" data-content="293."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="304."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-          <td class="diff-line-number" data-content="294."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="305."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
-          <td class="diff-line-number" data-content="295."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="306."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="296."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-        </tr>
-      </tbody>
-    </table>
+<div class="diff-checker">
+  <div class="diff-output">
+    <div class="diff-table-container" data-reactid="41">
+      <div class="diff-table-content" data-reactid="42">
+        <table class="diff-table" data-reactid="43">
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="1."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
+              <td class="diff-line-number" data-content="1."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="2."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
+              <td class="diff-line-number" data-content="2."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="3."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
+              <td class="diff-line-number" data-content="3."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="4."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
+              <td class="diff-line-number" data-content="4."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="5."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
+              <td class="diff-line-number" data-content="5."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="6."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
+              <td class="diff-line-number" data-content="6."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="7."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> </span><span class="diff-chunk diff-chunk-removed">How</span><span class="diff-chunk diff-chunk-equal"> to pay your Stamp Duty Land Tax (SDLT) and the time it </span><span class="diff-chunk diff-chunk-removed">takes for</span></td>
+              <td class="diff-line-number" data-content="7."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> </span><span class="diff-chunk diff-chunk-inserted">Find out how</span><span class="diff-chunk diff-chunk-equal"> to pay your Stamp Duty Land Tax (SDLT) and the time it </span><span class="diff-chunk diff-chunk-inserted">takes</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="8."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">  payment</span><span class="diff-chunk diff-chunk-equal"> to reach HM Revenue and Customs (HMRC).</span></td>
+              <td class="diff-line-number" data-content="8."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">  for payments</span><span class="diff-chunk diff-chunk-equal"> to reach HM Revenue and Customs (HMRC).</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="9."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
+              <td class="diff-line-number" data-content="9."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="10."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
+              <td class="diff-line-number" data-content="10."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="11."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="11."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="12."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="12."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="13."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a </span><span class="diff-chunk diff-chunk-equal">href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction </span><span class="diff-chunk diff-chunk-removed">Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="13."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a </span><span class="diff-chunk diff-chunk-inserted">rel="external" </span><span class="diff-chunk diff-chunk-equal">href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction </span><span class="diff-chunk diff-chunk-inserted">Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="14."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="15."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="14."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="16."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="15."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="17."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="16."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="18."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="17."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="19."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="18."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="20."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="19."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="21."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="20."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="22."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="21."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="23."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="22."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="24."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="23."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="25."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="24."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="26."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="25."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="27."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="26."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="28."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="27."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="29."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="28."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="30."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="29."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="31."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="30."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="32."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="31."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="33."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="32."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="34."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="33."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="35."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="34."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="36."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="35."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="37."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="36."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="38."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="37."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="39."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="38."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="40."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="39."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="41."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="40."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="42."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="41."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="43."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="42."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="44."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="43."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="45."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="44."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="46."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="45."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="47."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="46."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="48."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="47."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="49."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="48."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="50."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="49."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="51."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="50."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="52."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-chaps-bacs"&gt;Online</span><span class="diff-chunk diff-chunk-equal"> or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="51."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-chaps-and-bacs"&gt;Online</span><span class="diff-chunk diff-chunk-equal"> or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="53."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="52."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="54."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="53."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="55."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="54."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="56."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="55."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-chaps-and-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="57."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="56."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="58."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="57."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="59."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="58."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="60."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="59."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="61."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="60."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="62."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="61."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="63."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="62."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="64."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="63."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="65."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="64."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="66."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="65."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="67."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="66."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="68."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="67."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="69."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="68."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="70."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="69."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="71."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="70."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="72."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="71."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-chaps-and-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="73."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="72."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="74."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="73."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="75."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="74."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="76."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="75."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="77."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="76."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="78."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="77."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="79."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="78."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="80."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="79."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="81."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="80."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="82."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="81."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="83."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="82."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="84."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="83."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="85."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="84."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="86."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="85."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="87."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="86."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="88."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="87."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="89."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="88."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="90."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="89."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="91."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="90."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="92."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="91."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="93."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="92."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="94."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="93."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="95."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="94."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="96."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="95."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="97."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="96."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="98."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="97."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="99."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="98."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="100."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="99."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="101."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="100."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="102."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="101."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="103."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="102."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="104."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+              <td class="diff-line-number" data-content="103."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="105."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="104."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="106."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="105."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="107."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="106."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="108."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="107."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="109."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="108."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="110."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="109."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="111."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="110."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="112."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="111."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="113."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="112."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="114."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="113."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="115."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="114."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="116."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="115."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="117."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="116."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="118."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="117."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="119."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="118."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="120."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="119."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="121."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="120."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="122."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="121."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="123."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="122."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="124."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="123."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="125."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="124."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="126."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="125."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="127."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="126."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="128."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="127."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="129."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="128."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="130."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="129."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="131."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="130."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="132."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="131."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="133."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="132."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="134."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="133."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="135."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="134."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="136."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="135."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="137."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="136."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="138."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="137."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="139."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="138."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="140."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="139."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="141."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="140."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="142."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+              <td class="diff-line-number" data-content="141."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="143."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="142."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="144."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="143."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="145."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="144."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="146."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="145."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="147."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="146."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="148."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="147."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="149."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="148."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="150."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="149."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="151."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="150."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="152."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    Barclays Bank Plc</span></td>
+              <td class="diff-line-number" data-content="151."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    Barclays Bank Plc</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="153."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;1 Churchill Place</span></td>
+              <td class="diff-line-number" data-content="152."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;1 Churchill Place</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="154."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
+              <td class="diff-line-number" data-content="153."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="155."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;United Kingdom</span></td>
+              <td class="diff-line-number" data-content="154."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;United Kingdom</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="156."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-removed">5HO</span></td>
+              <td class="diff-line-number" data-content="155."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-inserted">5HP</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="157."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="156."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="158."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="157."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="159."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="158."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="160."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="159."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="161."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="160."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="162."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="161."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="163."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="162."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="164."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">&lt;p&gt;You’ll pay a 1.5% fee if you use a credit card. The fee isn’t refundable.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="163."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">&lt;p&gt;There is a fee for credit cards.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="165."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="166."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="167."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;You may be directed to use a &lt;a href="https://www.gov.uk/help/beta"&gt;beta&lt;/a&gt; service when you pay online. This is replacing BillPay.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="168."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="169."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="164."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="170."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="165."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="171."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="166."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="172."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="167."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="173."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="168."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="174."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="169."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="175."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="170."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="176."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to </span><span class="diff-chunk diff-chunk-removed">circumvent</span><span class="diff-chunk diff-chunk-equal"> this restriction.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="171."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to </span><span class="diff-chunk diff-chunk-inserted">get around</span><span class="diff-chunk diff-chunk-equal"> this restriction.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="177."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="172."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="178."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="173."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="179."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="174."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="180."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="175."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="181."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="176."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="182."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="177."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="183."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="178."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="184."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="179."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="185."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="180."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="186."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="181."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="187."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="182."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="188."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="183."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="189."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="184."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="190."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="185."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="191."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="186."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="192."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="187."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="193."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="188."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="194."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="189."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="195."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="190."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="196."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="191."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="197."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="192."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="198."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="193."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="199."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="194."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="200."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="195."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="201."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="196."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="202."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="197."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="203."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="198."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="204."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="199."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="205."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="200."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="206."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">&lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="201."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">&lt;p&gt;You can pay up to £10,000 at the Post Office without being charged using:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="207."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;You can pay at the Post Office by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="202."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="208."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="203."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="204."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">      &lt;li&gt;cheque (if accepted)&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="205."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">      &lt;li&gt;cash&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="206."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">      &lt;li&gt;debit card&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="207."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="208."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="209."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;p&gt;&lt;a rel="external" href="http://www.postoffice.co.uk/branch-finder"&gt;Contact your local Post Office branch&lt;/a&gt; to check if you can pay by cheque.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="209."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="210."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="210."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="211."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="211."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="212."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="212."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="213."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="213."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="214."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="214."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="215."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="215."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="216."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="216."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="217."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="217."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="218."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="218."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="219."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="219."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="220."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="220."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="221."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="221."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="222."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="222."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="223."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="223."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="224."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="224."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="225."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="225."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="226."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="226."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="227."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="227."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="228."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="228."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="229."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="229."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="230."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="230."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="231."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="231."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return </span><span class="diff-chunk diff-chunk-removed">or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your</span><span class="diff-chunk diff-chunk-equal"> payment to:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="232."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return </span><span class="diff-chunk diff-chunk-inserted">and wish to pay by cheque at the same time, please send your return and</span><span class="diff-chunk diff-chunk-equal"> payment to:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="232."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="233."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="233."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="234."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="234."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="235."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="235."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
+              <td class="diff-line-number" data-content="236."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="236."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
+              <td class="diff-line-number" data-content="237."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="237."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
+              <td class="diff-line-number" data-content="238."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="238."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
+              <td class="diff-line-number" data-content="239."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="239."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
+              <td class="diff-line-number" data-content="240."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="240."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
+              <td class="diff-line-number" data-content="241."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="241."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="242."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="242."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="243."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="243."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="244."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="244."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-removed">you’re using the DX service send to:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="245."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-inserted">you filed electronically but choose to pay by cheque, please send your payment, enclosing a payslip or quoting a &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; to avoid delay</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="245."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="246."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="247."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="248."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="249."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;Rapid Data Capture Centre</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="250."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;DX725593</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="251."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;Bootle 9</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="252."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="253."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="254."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="255."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="256."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="246."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="257."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="247."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="258."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="248."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="259."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
+              <td class="diff-line-number" data-content="249."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="260."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
+              <td class="diff-line-number" data-content="250."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="261."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
+              <td class="diff-line-number" data-content="251."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="262."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="252."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="263."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="253."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="264."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="254."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="265."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="255."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="266."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="256."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="267."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="257."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="268."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="258."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="269."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="259."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="270."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="260."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="271."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="261."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="272."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="262."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="273."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="263."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="274."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
+              <td class="diff-line-number" data-content="264."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="275."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
+              <td class="diff-line-number" data-content="265."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="276."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
+              <td class="diff-line-number" data-content="266."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="277."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
+              <td class="diff-line-number" data-content="267."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="278."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
+              <td class="diff-line-number" data-content="268."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="279."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="269."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="280."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
+              <td class="diff-line-number" data-content="270."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="281."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="271."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="282."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
+              <td class="diff-line-number" data-content="272."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="283."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
+              <td class="diff-line-number" data-content="273."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="284."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
+              <td class="diff-line-number" data-content="274."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="285."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
+              <td class="diff-line-number" data-content="275."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="286."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
+              <td class="diff-line-number" data-content="276."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="287."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
+              <td class="diff-line-number" data-content="277."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="288."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
+              <td class="diff-line-number" data-content="278."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="289."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
+              <td class="diff-line-number" data-content="279."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="290."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
+              <td class="diff-line-number" data-content="280."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="291."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
+              <td class="diff-line-number" data-content="281."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="292."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
+              <td class="diff-line-number" data-content="282."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="293."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
+              <td class="diff-line-number" data-content="283."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="294."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
+              <td class="diff-line-number" data-content="284."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="295."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
+              <td class="diff-line-number" data-content="285."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="296."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
+              <td class="diff-line-number" data-content="286."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="297."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="287."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="298."></td>
+              <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
+              <td class="diff-line-number" data-content="288."></td>
+              <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="299."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-removed">'2016-02-29T09:30:12.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="289."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-inserted">'2016-07-27T10:49:59.000+01:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="300."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
+              <td class="diff-line-number" data-content="290."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="301."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
+              <td class="diff-line-number" data-content="291."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="302."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+              <td class="diff-line-number" data-content="292."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="303."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
+              <td class="diff-line-number" data-content="293."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="304."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+              <td class="diff-line-number" data-content="294."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="305."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
+              <td class="diff-line-number" data-content="295."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="306."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="296."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
 </div>

--- a/historical-frontend/v2-v4.html
+++ b/historical-frontend/v2-v4.html
@@ -4,7 +4,7 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
 ---
 
 {% include_relative _heading.html %}
-{% include_relative _select.html from="v2" to="v4" %}
+{% include_relative _compare.html from=2 to=4 %}
 
 <div class="diff-checker">
   <div class="diff-output">

--- a/historical-frontend/v3-v1.html
+++ b/historical-frontend/v3-v1.html
@@ -4,7 +4,7 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
 ---
 
 {% include_relative _heading.html %}
-{% include_relative _select.html from="v3" to="v1" %}
+{% include_relative _compare.html from=3 to=1 %}
 
 <div class="diff-checker">
   <div class="diff-output">

--- a/historical-frontend/v3-v1.html
+++ b/historical-frontend/v3-v1.html
@@ -6,1890 +6,1894 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
 {% include_relative _heading.html %}
 {% include_relative _select.html from="v3" to="v1" %}
 
-<div class="diff-table-container" data-reactid="41">
-  <div class="diff-table-content" data-reactid="42">
-    <table class="diff-table" data-reactid="43">
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="1."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
-          <td class="diff-line-number" data-content="1."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="2."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
-          <td class="diff-line-number" data-content="2."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="3."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
-          <td class="diff-line-number" data-content="3."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="4."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
-          <td class="diff-line-number" data-content="4."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="5."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
-          <td class="diff-line-number" data-content="5."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="6."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
-          <td class="diff-line-number" data-content="6."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="7."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> How to pay your Stamp Duty Land Tax (SDLT) and the time it takes for</span></td>
-          <td class="diff-line-number" data-content="7."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> How to pay your Stamp Duty Land Tax (SDLT) and the time it takes for</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="8."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  payment to reach HM Revenue and Customs (HMRC).</span></td>
-          <td class="diff-line-number" data-content="8."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  payment to reach HM Revenue and Customs (HMRC).</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="9."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
-          <td class="diff-line-number" data-content="9."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="10."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
-          <td class="diff-line-number" data-content="10."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="11."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="11."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="12."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="12."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="13."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="13."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="14."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="14."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="15."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="15."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="16."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="16."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="17."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="17."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="18."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="18."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="19."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="19."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="20."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="20."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="21."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="21."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="22."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="22."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="23."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="23."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="24."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="24."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="25."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="25."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="26."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="26."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="27."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="27."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="28."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="28."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="29."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="29."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="30."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="30."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="31."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="31."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="32."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="32."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="33."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="33."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="34."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="34."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="35."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="35."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="36."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="36."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="37."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="37."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="38."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="38."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="39."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="39."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="40."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="40."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="41."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="41."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="42."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="42."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="43."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="43."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="44."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="44."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="45."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="45."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="46."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="46."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="47."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="47."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="48."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="48."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="49."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="49."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="50."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="50."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="51."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="51."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="52."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-chaps-bacs"&gt;Online or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="52."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-chaps-bacs"&gt;Online or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="53."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="53."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="54."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="54."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="55."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="55."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="56."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="56."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="57."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="57."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="58."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="58."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="59."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="59."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="60."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="60."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="61."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="61."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="62."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="62."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="63."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="63."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="64."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="64."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="65."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="65."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="66."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="66."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="67."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="67."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="68."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="68."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="69."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="69."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="70."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="70."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="71."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="71."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="72."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="72."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="73."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="73."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="74."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="74."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="75."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="75."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="76."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="76."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="77."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="77."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="78."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="78."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="79."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="79."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="80."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="80."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="81."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="81."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="82."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="82."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="83."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="83."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="84."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="84."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="85."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="85."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="86."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="86."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="87."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="87."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="88."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="88."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="89."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="89."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="90."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="90."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="91."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="91."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="92."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="92."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="93."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="93."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="94."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="94."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="95."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="95."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="96."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="96."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="97."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="97."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="98."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="98."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="99."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="99."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="100."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="100."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="101."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="101."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="102."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="102."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="103."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="103."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="104."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-          <td class="diff-line-number" data-content="104."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="105."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="105."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="106."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="106."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="107."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="107."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="108."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="108."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="109."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="109."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="110."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="110."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="111."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="111."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="112."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="112."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="113."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="113."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="114."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="114."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="115."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="115."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="116."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="116."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="117."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="117."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="118."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="118."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="119."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="119."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="120."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="120."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="121."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="121."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="122."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="122."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="123."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="123."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="124."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="124."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="125."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="125."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="126."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="126."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="127."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="127."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="128."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="128."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="129."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="129."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="130."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="130."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="131."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="131."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="132."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="132."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="133."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="133."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="134."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="134."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="135."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="135."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="136."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="136."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="137."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="137."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="138."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="138."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="139."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="139."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="140."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-removed">&lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="140."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-inserted">&lt;td&gt;GB05CITI08321012001020&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="141."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-removed">&lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="141."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-inserted">&lt;td&gt;CITIGB2L&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="142."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-          <td class="diff-line-number" data-content="142."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="143."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="143."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="144."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="144."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="145."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="145."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="146."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="146."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="147."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="147."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="148."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="148."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="149."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="149."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="150."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="150."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="151."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="151."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="152."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">Barclays Bank Plc</span></td>
-          <td class="diff-line-number" data-content="152."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">Citibank N A</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="153."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;1 Churchill Place</span></td>
-          <td class="diff-line-number" data-content="153."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;Citigroup Centre</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="154."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;Canary Wharf 33</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="155."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;Canada Square</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="154."></td>
-          <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
-          <td class="diff-line-number" data-content="156."></td>
-          <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="155."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;United Kingdom</span></td>
-          <td class="diff-line-number" data-content="157."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-inserted">5LB</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="156."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-removed">5HP</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="157."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="158."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="158."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="159."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="159."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="160."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="160."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="161."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="161."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="162."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="162."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="163."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="163."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="164."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="164."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">&lt;p&gt;There is a fee for credit cards.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="165."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">&lt;p&gt;You’ll pay a 1.5% fee if you use a credit card. The fee isn’t refundable.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="166."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="167."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="168."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;p&gt;You may be directed to use a &lt;a href="https://www.gov.uk/help/beta"&gt;beta&lt;/a&gt; service when you pay online. This is replacing BillPay.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="169."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="165."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="170."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="166."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="171."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="167."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="172."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="168."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="173."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="169."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="174."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="170."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="175."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="171."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="176."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="172."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to circumvent this restriction.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="177."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to circumvent this restriction.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="173."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="178."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="174."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="179."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="175."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="180."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="176."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="181."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="177."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="182."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="178."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="183."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="179."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="184."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="180."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="185."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="181."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="186."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="182."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="187."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="183."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="188."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="184."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="189."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="185."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="190."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="186."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="191."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="187."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="192."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="188."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="193."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="189."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="194."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="190."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="195."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="191."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="196."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="192."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="197."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="193."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="198."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="194."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="199."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="195."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="200."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="196."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="201."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="197."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="202."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="198."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="203."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="199."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="204."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="200."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="205."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="201."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="206."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="202."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="207."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="203."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay at the Post Office by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="208."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay at the Post Office by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="204."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="209."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="205."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="210."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="206."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="211."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="207."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="212."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="208."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="213."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="209."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="214."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="210."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="215."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="211."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="216."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="212."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="217."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="213."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="218."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="214."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="219."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="215."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="220."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="216."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="221."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="217."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="222."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="218."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="223."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="219."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="224."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="220."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="225."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="221."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="226."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="222."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="227."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="223."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="228."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="224."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="229."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="225."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="230."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="226."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="231."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="227."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your payment to:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="232."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your payment to:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="228."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="233."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="229."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="234."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="230."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="235."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="231."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
-          <td class="diff-line-number" data-content="236."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="232."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
-          <td class="diff-line-number" data-content="237."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="233."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
-          <td class="diff-line-number" data-content="238."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="234."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
-          <td class="diff-line-number" data-content="239."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="235."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
-          <td class="diff-line-number" data-content="240."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="236."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
-          <td class="diff-line-number" data-content="241."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="237."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="242."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="238."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="243."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="239."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="244."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="240."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re using the DX service send to:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="245."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re using the DX service send to:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="241."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="246."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="242."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="247."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="243."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="248."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="244."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
-          <td class="diff-line-number" data-content="249."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="245."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Rapid Data Capture Centre</span></td>
-          <td class="diff-line-number" data-content="250."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Rapid Data Capture Centre</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="246."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;DX725593</span></td>
-          <td class="diff-line-number" data-content="251."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;DX725593</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="247."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Bootle 9</span></td>
-          <td class="diff-line-number" data-content="252."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Bootle 9</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="248."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="253."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="249."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="254."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="250."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="255."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="251."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque to:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="256."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque to:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="252."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="257."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="253."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="258."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="254."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="259."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="255."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
-          <td class="diff-line-number" data-content="260."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="256."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
-          <td class="diff-line-number" data-content="261."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="257."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
-          <td class="diff-line-number" data-content="262."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="258."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="263."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="259."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="264."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="260."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="265."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="261."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="266."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="262."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="267."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="263."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="268."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="264."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="269."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="265."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="270."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="266."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="271."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="267."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="272."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="268."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="273."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="269."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="274."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="270."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
-          <td class="diff-line-number" data-content="275."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="271."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
-          <td class="diff-line-number" data-content="276."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="272."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
-          <td class="diff-line-number" data-content="277."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="273."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
-          <td class="diff-line-number" data-content="278."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="274."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
-          <td class="diff-line-number" data-content="279."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="275."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="280."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="276."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
-          <td class="diff-line-number" data-content="281."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="277."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="282."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="278."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
-          <td class="diff-line-number" data-content="283."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="279."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
-          <td class="diff-line-number" data-content="284."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="280."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
-          <td class="diff-line-number" data-content="285."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="281."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
-          <td class="diff-line-number" data-content="286."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="282."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
-          <td class="diff-line-number" data-content="287."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="283."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
-          <td class="diff-line-number" data-content="288."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="284."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
-          <td class="diff-line-number" data-content="289."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="285."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
-          <td class="diff-line-number" data-content="290."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="286."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
-          <td class="diff-line-number" data-content="291."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="287."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
-          <td class="diff-line-number" data-content="292."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="288."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
-          <td class="diff-line-number" data-content="293."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="289."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
-          <td class="diff-line-number" data-content="294."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="290."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
-          <td class="diff-line-number" data-content="295."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="291."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
-          <td class="diff-line-number" data-content="296."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="292."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
-          <td class="diff-line-number" data-content="297."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="293."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="298."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="294."></td>
-          <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
-          <td class="diff-line-number" data-content="299."></td>
-          <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="295."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-removed">'2016-04-01T08:00:06.000+01:00'</span></td>
-          <td class="diff-line-number" data-content="300."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-inserted">'2015-12-02T14:31:42.000+00:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="296."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
-          <td class="diff-line-number" data-content="301."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="297."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
-          <td class="diff-line-number" data-content="302."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="298."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-          <td class="diff-line-number" data-content="303."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="299."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
-          <td class="diff-line-number" data-content="304."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="300."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-          <td class="diff-line-number" data-content="305."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="301."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
-          <td class="diff-line-number" data-content="306."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="302."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="307."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
-        </tr>
-      </tbody>
-    </table>
+<div class="diff-checker">
+  <div class="diff-output">
+    <div class="diff-table-container" data-reactid="41">
+      <div class="diff-table-content" data-reactid="42">
+        <table class="diff-table" data-reactid="43">
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="1."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
+              <td class="diff-line-number" data-content="1."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="2."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
+              <td class="diff-line-number" data-content="2."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="3."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
+              <td class="diff-line-number" data-content="3."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="4."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
+              <td class="diff-line-number" data-content="4."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="5."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
+              <td class="diff-line-number" data-content="5."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="6."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
+              <td class="diff-line-number" data-content="6."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="7."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> How to pay your Stamp Duty Land Tax (SDLT) and the time it takes for</span></td>
+              <td class="diff-line-number" data-content="7."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> How to pay your Stamp Duty Land Tax (SDLT) and the time it takes for</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="8."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  payment to reach HM Revenue and Customs (HMRC).</span></td>
+              <td class="diff-line-number" data-content="8."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  payment to reach HM Revenue and Customs (HMRC).</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="9."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
+              <td class="diff-line-number" data-content="9."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="10."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
+              <td class="diff-line-number" data-content="10."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="11."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="11."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="12."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="12."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="13."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="13."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="14."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="14."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="15."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="15."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="16."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="16."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="17."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="17."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="18."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="18."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="19."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="19."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="20."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="20."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="21."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="21."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="22."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="22."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="23."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="23."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="24."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="24."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="25."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="25."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="26."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="26."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="27."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="27."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="28."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="28."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="29."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="29."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="30."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="30."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="31."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="31."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="32."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="32."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="33."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="33."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="34."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="34."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="35."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="35."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="36."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="36."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="37."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="37."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="38."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="38."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="39."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="39."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="40."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="40."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="41."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="41."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="42."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="42."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="43."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="43."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="44."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="44."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="45."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="45."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="46."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="46."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="47."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="47."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="48."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="48."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="49."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="49."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="50."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="50."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="51."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="51."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="52."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-chaps-bacs"&gt;Online or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="52."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-chaps-bacs"&gt;Online or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="53."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="53."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="54."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="54."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="55."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="55."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="56."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="56."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="57."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="57."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="58."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="58."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="59."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="59."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="60."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="60."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="61."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="61."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="62."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="62."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="63."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="63."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="64."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="64."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="65."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="65."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="66."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="66."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="67."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="67."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="68."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="68."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="69."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="69."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="70."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="70."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="71."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="71."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="72."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="72."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="73."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="73."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="74."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="74."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="75."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="75."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="76."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="76."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="77."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="77."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="78."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="78."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="79."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="79."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="80."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="80."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="81."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="81."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="82."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="82."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="83."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="83."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="84."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="84."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="85."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="85."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="86."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="86."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="87."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="87."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="88."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="88."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="89."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="89."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="90."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="90."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="91."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="91."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="92."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="92."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="93."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="93."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="94."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="94."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="95."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="95."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="96."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="96."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="97."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="97."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="98."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="98."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="99."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="99."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="100."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="100."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="101."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="101."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="102."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="102."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="103."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="103."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="104."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+              <td class="diff-line-number" data-content="104."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="105."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="105."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="106."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="106."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="107."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="107."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="108."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="108."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="109."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="109."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="110."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="110."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="111."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="111."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="112."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="112."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="113."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="113."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="114."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="114."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="115."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="115."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="116."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="116."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="117."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="117."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="118."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="118."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="119."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="119."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="120."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="120."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="121."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="121."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="122."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="122."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="123."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="123."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="124."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="124."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="125."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="125."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="126."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="126."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="127."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="127."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="128."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="128."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="129."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="129."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="130."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="130."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="131."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="131."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="132."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="132."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="133."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="133."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="134."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="134."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="135."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="135."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="136."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="136."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="137."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="137."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="138."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="138."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="139."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="139."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="140."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-removed">&lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="140."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-inserted">&lt;td&gt;GB05CITI08321012001020&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="141."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-removed">&lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="141."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-inserted">&lt;td&gt;CITIGB2L&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="142."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+              <td class="diff-line-number" data-content="142."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="143."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="143."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="144."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="144."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="145."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="145."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="146."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="146."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="147."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="147."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="148."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="148."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="149."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="149."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="150."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="150."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="151."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="151."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="152."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">Barclays Bank Plc</span></td>
+              <td class="diff-line-number" data-content="152."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">Citibank N A</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="153."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;1 Churchill Place</span></td>
+              <td class="diff-line-number" data-content="153."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;Citigroup Centre</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="154."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;Canary Wharf 33</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="155."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;Canada Square</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="154."></td>
+              <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
+              <td class="diff-line-number" data-content="156."></td>
+              <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="155."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;United Kingdom</span></td>
+              <td class="diff-line-number" data-content="157."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-inserted">5LB</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="156."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-removed">5HP</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="157."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="158."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="158."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="159."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="159."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="160."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="160."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="161."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="161."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="162."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="162."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="163."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="163."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="164."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="164."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">&lt;p&gt;There is a fee for credit cards.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="165."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">&lt;p&gt;You’ll pay a 1.5% fee if you use a credit card. The fee isn’t refundable.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="166."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="167."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="168."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;p&gt;You may be directed to use a &lt;a href="https://www.gov.uk/help/beta"&gt;beta&lt;/a&gt; service when you pay online. This is replacing BillPay.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="169."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="165."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="170."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="166."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="171."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="167."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="172."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="168."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="173."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="169."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="174."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="170."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="175."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="171."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="176."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="172."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to circumvent this restriction.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="177."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to circumvent this restriction.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="173."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="178."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="174."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="179."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="175."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="180."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="176."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="181."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="177."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="182."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="178."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="183."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="179."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="184."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="180."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="185."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="181."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="186."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="182."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="187."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="183."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="188."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="184."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="189."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="185."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="190."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="186."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="191."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="187."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="192."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="188."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="193."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="189."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="194."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="190."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="195."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="191."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="196."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="192."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="197."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="193."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="198."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="194."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="199."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="195."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="200."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="196."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="201."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="197."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="202."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="198."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="203."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="199."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="204."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="200."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="205."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="201."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="206."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="202."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="207."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="203."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay at the Post Office by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="208."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay at the Post Office by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="204."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="209."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="205."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="210."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="206."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="211."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="207."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="212."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="208."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="213."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="209."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="214."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="210."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="215."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="211."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="216."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="212."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="217."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="213."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="218."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="214."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="219."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="215."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="220."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="216."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="221."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="217."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="222."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="218."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="223."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="219."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="224."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="220."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="225."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="221."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="226."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="222."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="227."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="223."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="228."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="224."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="229."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="225."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="230."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="226."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="231."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="227."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your payment to:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="232."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your payment to:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="228."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="233."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="229."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="234."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="230."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="235."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="231."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
+              <td class="diff-line-number" data-content="236."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="232."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
+              <td class="diff-line-number" data-content="237."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="233."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
+              <td class="diff-line-number" data-content="238."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="234."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
+              <td class="diff-line-number" data-content="239."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="235."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
+              <td class="diff-line-number" data-content="240."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="236."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
+              <td class="diff-line-number" data-content="241."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="237."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="242."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="238."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="243."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="239."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="244."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="240."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re using the DX service send to:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="245."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re using the DX service send to:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="241."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="246."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="242."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="247."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="243."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="248."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="244."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
+              <td class="diff-line-number" data-content="249."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="245."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Rapid Data Capture Centre</span></td>
+              <td class="diff-line-number" data-content="250."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Rapid Data Capture Centre</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="246."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;DX725593</span></td>
+              <td class="diff-line-number" data-content="251."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;DX725593</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="247."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Bootle 9</span></td>
+              <td class="diff-line-number" data-content="252."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Bootle 9</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="248."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="253."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="249."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="254."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="250."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="255."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="251."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque to:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="256."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque to:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="252."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="257."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="253."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="258."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="254."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="259."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="255."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
+              <td class="diff-line-number" data-content="260."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="256."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
+              <td class="diff-line-number" data-content="261."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="257."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
+              <td class="diff-line-number" data-content="262."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="258."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="263."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="259."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="264."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="260."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="265."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="261."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="266."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="262."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="267."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="263."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="268."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="264."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="269."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="265."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="270."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="266."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="271."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="267."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="272."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="268."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="273."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="269."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="274."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="270."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
+              <td class="diff-line-number" data-content="275."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="271."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
+              <td class="diff-line-number" data-content="276."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="272."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
+              <td class="diff-line-number" data-content="277."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="273."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
+              <td class="diff-line-number" data-content="278."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="274."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
+              <td class="diff-line-number" data-content="279."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="275."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="280."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="276."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
+              <td class="diff-line-number" data-content="281."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="277."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="282."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="278."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
+              <td class="diff-line-number" data-content="283."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="279."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
+              <td class="diff-line-number" data-content="284."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="280."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
+              <td class="diff-line-number" data-content="285."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="281."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
+              <td class="diff-line-number" data-content="286."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="282."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
+              <td class="diff-line-number" data-content="287."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="283."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
+              <td class="diff-line-number" data-content="288."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="284."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
+              <td class="diff-line-number" data-content="289."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="285."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
+              <td class="diff-line-number" data-content="290."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="286."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
+              <td class="diff-line-number" data-content="291."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="287."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
+              <td class="diff-line-number" data-content="292."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="288."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
+              <td class="diff-line-number" data-content="293."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="289."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
+              <td class="diff-line-number" data-content="294."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="290."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
+              <td class="diff-line-number" data-content="295."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="291."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
+              <td class="diff-line-number" data-content="296."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="292."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
+              <td class="diff-line-number" data-content="297."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="293."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="298."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="294."></td>
+              <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
+              <td class="diff-line-number" data-content="299."></td>
+              <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="295."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-removed">'2016-04-01T08:00:06.000+01:00'</span></td>
+              <td class="diff-line-number" data-content="300."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-inserted">'2015-12-02T14:31:42.000+00:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="296."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
+              <td class="diff-line-number" data-content="301."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="297."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
+              <td class="diff-line-number" data-content="302."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="298."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+              <td class="diff-line-number" data-content="303."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="299."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
+              <td class="diff-line-number" data-content="304."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="300."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+              <td class="diff-line-number" data-content="305."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="301."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
+              <td class="diff-line-number" data-content="306."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="302."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="307."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
 </div>

--- a/historical-frontend/v3-v2.html
+++ b/historical-frontend/v3-v2.html
@@ -4,7 +4,7 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
 ---
 
 {% include_relative _heading.html %}
-{% include_relative _select.html from="v3" to="v2" %}
+{% include_relative _compare.html from=3 to=2 %}
 
 <div class="diff-checker">
   <div class="diff-output">

--- a/historical-frontend/v3-v2.html
+++ b/historical-frontend/v3-v2.html
@@ -6,1871 +6,1875 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
 {% include_relative _heading.html %}
 {% include_relative _select.html from="v3" to="v2" %}
 
-<div class="diff-table-container" data-reactid="41">
-  <div class="diff-table-content" data-reactid="42">
-    <table class="diff-table" data-reactid="43">
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="1."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
-          <td class="diff-line-number" data-content="1."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="2."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
-          <td class="diff-line-number" data-content="2."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="3."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
-          <td class="diff-line-number" data-content="3."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="4."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
-          <td class="diff-line-number" data-content="4."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="5."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
-          <td class="diff-line-number" data-content="5."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="6."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
-          <td class="diff-line-number" data-content="6."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="7."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> How to pay your Stamp Duty Land Tax (SDLT) and the time it takes for</span></td>
-          <td class="diff-line-number" data-content="7."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> How to pay your Stamp Duty Land Tax (SDLT) and the time it takes for</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="8."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  payment to reach HM Revenue and Customs (HMRC).</span></td>
-          <td class="diff-line-number" data-content="8."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  payment to reach HM Revenue and Customs (HMRC).</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="9."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
-          <td class="diff-line-number" data-content="9."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="10."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
-          <td class="diff-line-number" data-content="10."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="11."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="11."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="12."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="12."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="13."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="13."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="14."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="14."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="15."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="15."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="16."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="16."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="17."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="17."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="18."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="18."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="19."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="19."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="20."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="20."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="21."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="21."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="22."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="22."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="23."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="23."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="24."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="24."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="25."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="25."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="26."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="26."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="27."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="27."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="28."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="28."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="29."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="29."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="30."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="30."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="31."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="31."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="32."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="32."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="33."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="33."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="34."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="34."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="35."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="35."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="36."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="36."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="37."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="37."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="38."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="38."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="39."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="39."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="40."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="40."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="41."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="41."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="42."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="42."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="43."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="43."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="44."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="44."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="45."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="45."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="46."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="46."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="47."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="47."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="48."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="48."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="49."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="49."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="50."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="50."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="51."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="51."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="52."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-chaps-bacs"&gt;Online or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="52."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-chaps-bacs"&gt;Online or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="53."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="53."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="54."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="54."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="55."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="55."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="56."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="56."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="57."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="57."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="58."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="58."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="59."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="59."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="60."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="60."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="61."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="61."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="62."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="62."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="63."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="63."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="64."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="64."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="65."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="65."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="66."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="66."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="67."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="67."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="68."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="68."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="69."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="69."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="70."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="70."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="71."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="71."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="72."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="72."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="73."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="73."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="74."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="74."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="75."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="75."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="76."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="76."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="77."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="77."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="78."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="78."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="79."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="79."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="80."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="80."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="81."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="81."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="82."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="82."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="83."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="83."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="84."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="84."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="85."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="85."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="86."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="86."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="87."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="87."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="88."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="88."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="89."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="89."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="90."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="90."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="91."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="91."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="92."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="92."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="93."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="93."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="94."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="94."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="95."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="95."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="96."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="96."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="97."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="97."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="98."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="98."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="99."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="99."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="100."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="100."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="101."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="101."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="102."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="102."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="103."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="103."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="104."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-          <td class="diff-line-number" data-content="104."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="105."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="105."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="106."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="106."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="107."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="107."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="108."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="108."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="109."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="109."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="110."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="110."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="111."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="111."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="112."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="112."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="113."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="113."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="114."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="114."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="115."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="115."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="116."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="116."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="117."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="117."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="118."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="118."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="119."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="119."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="120."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="120."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="121."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="121."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="122."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="122."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="123."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="123."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="124."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="124."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="125."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="125."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="126."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="126."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="127."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="127."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="128."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="128."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="129."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="129."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="130."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="130."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="131."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="131."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="132."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="132."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="133."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="133."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="134."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="134."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="135."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="135."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="136."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="136."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="137."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="137."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="138."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="138."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="139."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="139."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="140."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="140."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="141."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="141."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="142."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-          <td class="diff-line-number" data-content="142."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="143."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="143."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="144."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="144."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="145."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="145."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="146."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="146."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="147."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="147."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="148."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="148."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="149."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="149."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="150."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="150."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="151."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="151."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="152."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    Barclays Bank Plc</span></td>
-          <td class="diff-line-number" data-content="152."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    Barclays Bank Plc</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="153."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;1 Churchill Place</span></td>
-          <td class="diff-line-number" data-content="153."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;1 Churchill Place</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="154."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
-          <td class="diff-line-number" data-content="154."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="155."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;United Kingdom</span></td>
-          <td class="diff-line-number" data-content="155."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;United Kingdom</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="156."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-removed">5HP</span></td>
-          <td class="diff-line-number" data-content="156."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-inserted">5HO</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="157."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="157."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="158."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="158."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="159."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="159."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="160."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="160."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="161."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="161."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="162."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="162."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="163."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="163."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="164."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">&lt;p&gt;There is a fee for credit cards.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="164."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">&lt;p&gt;You’ll pay a 1.5% fee if you use a credit card. The fee isn’t refundable.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="165."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="166."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="167."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;p&gt;You may be directed to use a &lt;a href="https://www.gov.uk/help/beta"&gt;beta&lt;/a&gt; service when you pay online. This is replacing BillPay.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="168."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="165."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="169."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="166."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="170."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="167."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="171."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="168."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="172."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="169."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="173."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="170."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="174."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="171."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="175."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="172."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to circumvent this restriction.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="176."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to circumvent this restriction.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="173."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="177."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="174."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="178."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="175."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="179."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="176."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="180."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="177."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="181."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="178."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="182."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="179."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="183."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="180."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="184."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="181."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="185."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="182."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="186."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="183."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="187."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="184."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="188."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="185."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="189."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="186."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="190."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="187."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="191."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="188."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="192."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="189."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="193."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="190."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="194."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="191."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="195."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="192."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="196."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="193."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="197."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="194."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="198."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="195."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="199."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="196."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="200."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="197."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="201."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="198."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="202."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="199."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="203."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="200."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="204."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="201."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="205."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="202."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="206."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="203."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay at the Post Office by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="207."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay at the Post Office by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="204."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="208."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="205."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="209."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="206."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="210."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="207."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="211."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="208."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="212."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="209."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="213."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="210."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="214."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="211."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="215."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="212."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="216."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="213."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="217."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="214."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="218."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="215."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="219."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="216."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="220."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="217."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="221."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="218."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="222."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="219."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="223."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="220."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="224."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="221."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="225."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="222."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="226."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="223."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="227."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="224."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="228."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="225."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="229."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="226."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="230."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="227."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your payment to:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="231."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your payment to:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="228."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="232."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="229."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="233."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="230."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="234."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="231."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
-          <td class="diff-line-number" data-content="235."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="232."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
-          <td class="diff-line-number" data-content="236."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="233."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
-          <td class="diff-line-number" data-content="237."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="234."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
-          <td class="diff-line-number" data-content="238."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="235."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
-          <td class="diff-line-number" data-content="239."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="236."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
-          <td class="diff-line-number" data-content="240."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="237."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="241."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="238."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="242."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="239."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="243."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="240."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re using the DX service send to:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="244."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re using the DX service send to:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="241."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="245."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="242."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="246."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="243."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="247."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="244."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
-          <td class="diff-line-number" data-content="248."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="245."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Rapid Data Capture Centre</span></td>
-          <td class="diff-line-number" data-content="249."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Rapid Data Capture Centre</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="246."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;DX725593</span></td>
-          <td class="diff-line-number" data-content="250."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;DX725593</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="247."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Bootle 9</span></td>
-          <td class="diff-line-number" data-content="251."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Bootle 9</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="248."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="252."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="249."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="253."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="250."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="254."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="251."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque to:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="255."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque to:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="252."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="256."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="253."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="257."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="254."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="258."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="255."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
-          <td class="diff-line-number" data-content="259."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="256."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
-          <td class="diff-line-number" data-content="260."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="257."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
-          <td class="diff-line-number" data-content="261."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="258."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="262."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="259."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="263."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="260."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="264."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="261."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="265."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="262."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="266."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="263."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="267."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="264."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="268."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="265."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="269."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="266."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="270."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="267."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="271."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="268."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="272."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="269."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="273."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="270."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
-          <td class="diff-line-number" data-content="274."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="271."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
-          <td class="diff-line-number" data-content="275."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="272."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
-          <td class="diff-line-number" data-content="276."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="273."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
-          <td class="diff-line-number" data-content="277."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="274."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
-          <td class="diff-line-number" data-content="278."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="275."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="279."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="276."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
-          <td class="diff-line-number" data-content="280."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="277."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="281."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="278."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
-          <td class="diff-line-number" data-content="282."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="279."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
-          <td class="diff-line-number" data-content="283."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="280."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
-          <td class="diff-line-number" data-content="284."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="281."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
-          <td class="diff-line-number" data-content="285."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="282."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
-          <td class="diff-line-number" data-content="286."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="283."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
-          <td class="diff-line-number" data-content="287."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="284."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
-          <td class="diff-line-number" data-content="288."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="285."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
-          <td class="diff-line-number" data-content="289."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="286."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
-          <td class="diff-line-number" data-content="290."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="287."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
-          <td class="diff-line-number" data-content="291."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="288."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
-          <td class="diff-line-number" data-content="292."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="289."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
-          <td class="diff-line-number" data-content="293."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="290."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
-          <td class="diff-line-number" data-content="294."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="291."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
-          <td class="diff-line-number" data-content="295."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="292."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
-          <td class="diff-line-number" data-content="296."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="293."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="297."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="294."></td>
-          <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
-          <td class="diff-line-number" data-content="298."></td>
-          <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="295."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-removed">'2016-04-01T08:00:06.000+01:00'</span></td>
-          <td class="diff-line-number" data-content="299."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-inserted">'2016-02-29T09:30:12.000+00:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="296."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
-          <td class="diff-line-number" data-content="300."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="297."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
-          <td class="diff-line-number" data-content="301."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="298."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-          <td class="diff-line-number" data-content="302."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="299."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
-          <td class="diff-line-number" data-content="303."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="300."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-          <td class="diff-line-number" data-content="304."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="301."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
-          <td class="diff-line-number" data-content="305."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="302."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="306."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
-        </tr>
-      </tbody>
-    </table>
+<div class="diff-checker">
+  <div class="diff-output">
+    <div class="diff-table-container" data-reactid="41">
+      <div class="diff-table-content" data-reactid="42">
+        <table class="diff-table" data-reactid="43">
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="1."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
+              <td class="diff-line-number" data-content="1."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="2."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
+              <td class="diff-line-number" data-content="2."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="3."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
+              <td class="diff-line-number" data-content="3."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="4."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
+              <td class="diff-line-number" data-content="4."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="5."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
+              <td class="diff-line-number" data-content="5."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="6."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
+              <td class="diff-line-number" data-content="6."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="7."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> How to pay your Stamp Duty Land Tax (SDLT) and the time it takes for</span></td>
+              <td class="diff-line-number" data-content="7."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> How to pay your Stamp Duty Land Tax (SDLT) and the time it takes for</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="8."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  payment to reach HM Revenue and Customs (HMRC).</span></td>
+              <td class="diff-line-number" data-content="8."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  payment to reach HM Revenue and Customs (HMRC).</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="9."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
+              <td class="diff-line-number" data-content="9."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="10."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
+              <td class="diff-line-number" data-content="10."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="11."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="11."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="12."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="12."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="13."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="13."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="14."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="14."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="15."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="15."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="16."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="16."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="17."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="17."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="18."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="18."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="19."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="19."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="20."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="20."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="21."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="21."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="22."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="22."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="23."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="23."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="24."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="24."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="25."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="25."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="26."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="26."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="27."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="27."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="28."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="28."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="29."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="29."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="30."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="30."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="31."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="31."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="32."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="32."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="33."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="33."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="34."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="34."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="35."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="35."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="36."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="36."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="37."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="37."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="38."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="38."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="39."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="39."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="40."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="40."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="41."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="41."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="42."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="42."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="43."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="43."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="44."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="44."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="45."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="45."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="46."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="46."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="47."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="47."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="48."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="48."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="49."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="49."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="50."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="50."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="51."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="51."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="52."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-chaps-bacs"&gt;Online or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="52."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-chaps-bacs"&gt;Online or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="53."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="53."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="54."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="54."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="55."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="55."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="56."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="56."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="57."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="57."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="58."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="58."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="59."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="59."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="60."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="60."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="61."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="61."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="62."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="62."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="63."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="63."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="64."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="64."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="65."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="65."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="66."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="66."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="67."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="67."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="68."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="68."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="69."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="69."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="70."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="70."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="71."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="71."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="72."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="72."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="73."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="73."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="74."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="74."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="75."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="75."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="76."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="76."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="77."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="77."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="78."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="78."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="79."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="79."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="80."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="80."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="81."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="81."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="82."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="82."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="83."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="83."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="84."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="84."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="85."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="85."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="86."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="86."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="87."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="87."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="88."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="88."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="89."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="89."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="90."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="90."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="91."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="91."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="92."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="92."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="93."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="93."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="94."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="94."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="95."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="95."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="96."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="96."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="97."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="97."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="98."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="98."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="99."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="99."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="100."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="100."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="101."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="101."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="102."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="102."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="103."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="103."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="104."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+              <td class="diff-line-number" data-content="104."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="105."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="105."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="106."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="106."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="107."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="107."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="108."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="108."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="109."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="109."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="110."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="110."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="111."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="111."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="112."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="112."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="113."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="113."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="114."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="114."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="115."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="115."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="116."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="116."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="117."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="117."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="118."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="118."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="119."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="119."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="120."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="120."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="121."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="121."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="122."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="122."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="123."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="123."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="124."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="124."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="125."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="125."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="126."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="126."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="127."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="127."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="128."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="128."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="129."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="129."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="130."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="130."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="131."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="131."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="132."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="132."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="133."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="133."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="134."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="134."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="135."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="135."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="136."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="136."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="137."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="137."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="138."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="138."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="139."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="139."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="140."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="140."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="141."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="141."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="142."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+              <td class="diff-line-number" data-content="142."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="143."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="143."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="144."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="144."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="145."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="145."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="146."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="146."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="147."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="147."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="148."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="148."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="149."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="149."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="150."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="150."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="151."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="151."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="152."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    Barclays Bank Plc</span></td>
+              <td class="diff-line-number" data-content="152."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    Barclays Bank Plc</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="153."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;1 Churchill Place</span></td>
+              <td class="diff-line-number" data-content="153."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;1 Churchill Place</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="154."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
+              <td class="diff-line-number" data-content="154."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="155."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;United Kingdom</span></td>
+              <td class="diff-line-number" data-content="155."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;United Kingdom</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="156."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-removed">5HP</span></td>
+              <td class="diff-line-number" data-content="156."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-inserted">5HO</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="157."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="157."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="158."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="158."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="159."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="159."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="160."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="160."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="161."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="161."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="162."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="162."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="163."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="163."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="164."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">&lt;p&gt;There is a fee for credit cards.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="164."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">&lt;p&gt;You’ll pay a 1.5% fee if you use a credit card. The fee isn’t refundable.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="165."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="166."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="167."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;p&gt;You may be directed to use a &lt;a href="https://www.gov.uk/help/beta"&gt;beta&lt;/a&gt; service when you pay online. This is replacing BillPay.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="168."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="165."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="169."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="166."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="170."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="167."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="171."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="168."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="172."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="169."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="173."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="170."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="174."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="171."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="175."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="172."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to circumvent this restriction.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="176."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to circumvent this restriction.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="173."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="177."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="174."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="178."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="175."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="179."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="176."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="180."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="177."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="181."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="178."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="182."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="179."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="183."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="180."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="184."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="181."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="185."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="182."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="186."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="183."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="187."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="184."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="188."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="185."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="189."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="186."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="190."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="187."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="191."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="188."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="192."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="189."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="193."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="190."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="194."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="191."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="195."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="192."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="196."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="193."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="197."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="194."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="198."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="195."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="199."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="196."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="200."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="197."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="201."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="198."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="202."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="199."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="203."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="200."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="204."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="201."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="205."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="202."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="206."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="203."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay at the Post Office by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="207."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay at the Post Office by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="204."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="208."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="205."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="209."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="206."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="210."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="207."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="211."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="208."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="212."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="209."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="213."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="210."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="214."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="211."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="215."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="212."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="216."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="213."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="217."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="214."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="218."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="215."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="219."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="216."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="220."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="217."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="221."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="218."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="222."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="219."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="223."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="220."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="224."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="221."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="225."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="222."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="226."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="223."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="227."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="224."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="228."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="225."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="229."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="226."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="230."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="227."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your payment to:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="231."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your payment to:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="228."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="232."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="229."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="233."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="230."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="234."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="231."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
+              <td class="diff-line-number" data-content="235."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="232."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
+              <td class="diff-line-number" data-content="236."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="233."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
+              <td class="diff-line-number" data-content="237."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="234."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
+              <td class="diff-line-number" data-content="238."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="235."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
+              <td class="diff-line-number" data-content="239."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="236."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
+              <td class="diff-line-number" data-content="240."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="237."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="241."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="238."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="242."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="239."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="243."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="240."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re using the DX service send to:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="244."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re using the DX service send to:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="241."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="245."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="242."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="246."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="243."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="247."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="244."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
+              <td class="diff-line-number" data-content="248."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="245."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Rapid Data Capture Centre</span></td>
+              <td class="diff-line-number" data-content="249."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Rapid Data Capture Centre</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="246."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;DX725593</span></td>
+              <td class="diff-line-number" data-content="250."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;DX725593</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="247."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Bootle 9</span></td>
+              <td class="diff-line-number" data-content="251."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Bootle 9</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="248."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="252."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="249."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="253."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="250."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="254."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="251."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque to:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="255."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque to:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="252."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="256."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="253."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="257."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="254."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="258."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="255."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
+              <td class="diff-line-number" data-content="259."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="256."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
+              <td class="diff-line-number" data-content="260."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="257."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
+              <td class="diff-line-number" data-content="261."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="258."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="262."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="259."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="263."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="260."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="264."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="261."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="265."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="262."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="266."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="263."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="267."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="264."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="268."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="265."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="269."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="266."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="270."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="267."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="271."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="268."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="272."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="269."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="273."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="270."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
+              <td class="diff-line-number" data-content="274."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="271."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
+              <td class="diff-line-number" data-content="275."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="272."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
+              <td class="diff-line-number" data-content="276."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="273."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
+              <td class="diff-line-number" data-content="277."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="274."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
+              <td class="diff-line-number" data-content="278."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="275."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="279."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="276."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
+              <td class="diff-line-number" data-content="280."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="277."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="281."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="278."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
+              <td class="diff-line-number" data-content="282."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="279."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
+              <td class="diff-line-number" data-content="283."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="280."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
+              <td class="diff-line-number" data-content="284."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="281."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
+              <td class="diff-line-number" data-content="285."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="282."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
+              <td class="diff-line-number" data-content="286."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="283."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
+              <td class="diff-line-number" data-content="287."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="284."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
+              <td class="diff-line-number" data-content="288."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="285."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
+              <td class="diff-line-number" data-content="289."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="286."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
+              <td class="diff-line-number" data-content="290."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="287."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
+              <td class="diff-line-number" data-content="291."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="288."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
+              <td class="diff-line-number" data-content="292."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="289."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
+              <td class="diff-line-number" data-content="293."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="290."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
+              <td class="diff-line-number" data-content="294."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="291."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
+              <td class="diff-line-number" data-content="295."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="292."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
+              <td class="diff-line-number" data-content="296."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="293."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="297."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="294."></td>
+              <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
+              <td class="diff-line-number" data-content="298."></td>
+              <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="295."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-removed">'2016-04-01T08:00:06.000+01:00'</span></td>
+              <td class="diff-line-number" data-content="299."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-inserted">'2016-02-29T09:30:12.000+00:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="296."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
+              <td class="diff-line-number" data-content="300."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="297."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
+              <td class="diff-line-number" data-content="301."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="298."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+              <td class="diff-line-number" data-content="302."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="299."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
+              <td class="diff-line-number" data-content="303."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="300."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+              <td class="diff-line-number" data-content="304."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="301."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
+              <td class="diff-line-number" data-content="305."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="302."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="306."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
 </div>

--- a/historical-frontend/v3-v4.html
+++ b/historical-frontend/v3-v4.html
@@ -4,7 +4,7 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
 ---
 
 {% include_relative _heading.html %}
-{% include_relative _select.html from="v3" to="v4" %}
+{% include_relative _compare.html from=3 to=4 %}
 
 <div class="diff-checker">
   <div class="diff-output">

--- a/historical-frontend/v3-v4.html
+++ b/historical-frontend/v3-v4.html
@@ -6,1932 +6,1936 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
 {% include_relative _heading.html %}
 {% include_relative _select.html from="v3" to="v4" %}
 
-<div class="diff-table-container" data-reactid="41">
-  <div class="diff-table-content" data-reactid="42">
-    <table class="diff-table" data-reactid="43">
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="1."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
-          <td class="diff-line-number" data-content="1."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="2."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
-          <td class="diff-line-number" data-content="2."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="3."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
-          <td class="diff-line-number" data-content="3."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="4."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
-          <td class="diff-line-number" data-content="4."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="5."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
-          <td class="diff-line-number" data-content="5."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="6."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
-          <td class="diff-line-number" data-content="6."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="7."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> </span><span class="diff-chunk diff-chunk-removed">How</span><span class="diff-chunk diff-chunk-equal"> to pay your Stamp Duty Land Tax (SDLT) and the time it </span><span class="diff-chunk diff-chunk-removed">takes for</span></td>
-          <td class="diff-line-number" data-content="7."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> </span><span class="diff-chunk diff-chunk-inserted">Find out how</span><span class="diff-chunk diff-chunk-equal"> to pay your Stamp Duty Land Tax (SDLT) and the time it </span><span class="diff-chunk diff-chunk-inserted">takes</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="8."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">  payment</span><span class="diff-chunk diff-chunk-equal"> to reach HM Revenue and Customs (HMRC).</span></td>
-          <td class="diff-line-number" data-content="8."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">  for payments</span><span class="diff-chunk diff-chunk-equal"> to reach HM Revenue and Customs (HMRC).</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="9."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
-          <td class="diff-line-number" data-content="9."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="10."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
-          <td class="diff-line-number" data-content="10."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="11."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="11."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="12."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="12."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="13."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a </span><span class="diff-chunk diff-chunk-equal">href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction </span><span class="diff-chunk diff-chunk-removed">Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="13."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a </span><span class="diff-chunk diff-chunk-inserted">rel="external" </span><span class="diff-chunk diff-chunk-equal">href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction </span><span class="diff-chunk diff-chunk-inserted">Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="14."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="15."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="14."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="16."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="15."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="17."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="16."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="18."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="17."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="19."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="18."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="20."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="19."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="21."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="20."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="22."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="21."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="23."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="22."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="24."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="23."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="25."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="24."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="26."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="25."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="27."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="26."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="28."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="27."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="29."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="28."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="30."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="29."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="31."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="30."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="32."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="31."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="33."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="32."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="34."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="33."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="35."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="34."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="36."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="35."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="37."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="36."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="38."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="37."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="39."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="38."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="40."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="39."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="41."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="40."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="42."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="41."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="43."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="42."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="44."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="43."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="45."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="44."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="46."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="45."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="47."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="46."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="48."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="47."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="49."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="48."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="50."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="49."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="51."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="50."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="52."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-chaps-bacs"&gt;Online</span><span class="diff-chunk diff-chunk-equal"> or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="51."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-chaps-and-bacs"&gt;Online</span><span class="diff-chunk diff-chunk-equal"> or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="53."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="52."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="54."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="53."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="55."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="54."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="56."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="55."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-chaps-and-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="57."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="56."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="58."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="57."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="59."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="58."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="60."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="59."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="61."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="60."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="62."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="61."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="63."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="62."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="64."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="63."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="65."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="64."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="66."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="65."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="67."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="66."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="68."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="67."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="69."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="68."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="70."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="69."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="71."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="70."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="72."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="71."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-chaps-and-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="73."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="72."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="74."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="73."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="75."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="74."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="76."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="75."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="77."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="76."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="78."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="77."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="79."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="78."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="80."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="79."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="81."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="80."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="82."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="81."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="83."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="82."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="84."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="83."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="85."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="84."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="86."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="85."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="87."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="86."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="88."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="87."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="89."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="88."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="90."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="89."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="91."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="90."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="92."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="91."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="93."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="92."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="94."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="93."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="95."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="94."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="96."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="95."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="97."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="96."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="98."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="97."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="99."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="98."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="100."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="99."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="101."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="100."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="102."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="101."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="103."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="102."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="104."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-          <td class="diff-line-number" data-content="103."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="105."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="104."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="106."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="105."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="107."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="106."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="108."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="107."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="109."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="108."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="110."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="109."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="111."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="110."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="112."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="111."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="113."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="112."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="114."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="113."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="115."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="114."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="116."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="115."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="117."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="116."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="118."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="117."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="119."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="118."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="120."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="119."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="121."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="120."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="122."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="121."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="123."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="122."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="124."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="123."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="125."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="124."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="126."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="125."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="127."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="126."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="128."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="127."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="129."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="128."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="130."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="129."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="131."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="130."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="132."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="131."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="133."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="132."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="134."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="133."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="135."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="134."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="136."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="135."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="137."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="136."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="138."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="137."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="139."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="138."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="140."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="139."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="141."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="140."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="142."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-          <td class="diff-line-number" data-content="141."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="143."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="142."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="144."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="143."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="145."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="144."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="146."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="145."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="147."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="146."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="148."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="147."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="149."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="148."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="150."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="149."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="151."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="150."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="152."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    Barclays Bank Plc</span></td>
-          <td class="diff-line-number" data-content="151."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    Barclays Bank Plc</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="153."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;1 Churchill Place</span></td>
-          <td class="diff-line-number" data-content="152."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;1 Churchill Place</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="154."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
-          <td class="diff-line-number" data-content="153."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="155."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;United Kingdom</span></td>
-          <td class="diff-line-number" data-content="154."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;United Kingdom</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="156."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 5HP</span></td>
-          <td class="diff-line-number" data-content="155."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 5HP</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="157."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="156."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="158."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="157."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="159."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="158."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="160."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="159."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="161."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="160."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="162."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="161."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="163."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="162."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="164."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;There is a fee for credit cards.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="163."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;There is a fee for credit cards.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="165."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="164."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="166."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="165."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="167."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="166."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="168."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="167."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="169."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="168."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="170."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="169."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="171."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="170."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="172."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to </span><span class="diff-chunk diff-chunk-removed">circumvent</span><span class="diff-chunk diff-chunk-equal"> this restriction.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="171."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to </span><span class="diff-chunk diff-chunk-inserted">get around</span><span class="diff-chunk diff-chunk-equal"> this restriction.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="173."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="172."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="174."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="173."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="175."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="174."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="176."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="175."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="177."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="176."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="178."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="177."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="179."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="178."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="180."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="179."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="181."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="180."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="182."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="181."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="183."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="182."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="184."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="183."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="185."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="184."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="186."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="185."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="187."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="186."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="188."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="187."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="189."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="188."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="190."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="189."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="191."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="190."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="192."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="191."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="193."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="192."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="194."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="193."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="195."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="194."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="196."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="195."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="197."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="196."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="198."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="197."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="199."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="198."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="200."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="199."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="201."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="200."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="202."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">&lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="201."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">&lt;p&gt;You can pay up to £10,000 at the Post Office without being charged using:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="203."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;You can pay at the Post Office by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="202."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="204."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="203."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="204."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">      &lt;li&gt;cheque (if accepted)&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="205."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">      &lt;li&gt;cash&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="206."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">      &lt;li&gt;debit card&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="207."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="208."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="209."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;p&gt;&lt;a rel="external" href="http://www.postoffice.co.uk/branch-finder"&gt;Contact your local Post Office branch&lt;/a&gt; to check if you can pay by cheque.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="205."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="210."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="206."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="211."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="207."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="212."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="208."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="213."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="209."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="214."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="210."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="215."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="211."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="216."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="212."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="217."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="213."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="218."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="214."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="219."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="215."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="220."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="216."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="221."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="217."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="222."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="218."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="223."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="219."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="224."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="220."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="225."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="221."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="226."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="222."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="227."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="223."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="228."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="224."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="229."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="225."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="230."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="226."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="231."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="227."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return </span><span class="diff-chunk diff-chunk-removed">or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your</span><span class="diff-chunk diff-chunk-equal"> payment to:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="232."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return </span><span class="diff-chunk diff-chunk-inserted">and wish to pay by cheque at the same time, please send your return and</span><span class="diff-chunk diff-chunk-equal"> payment to:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="228."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="233."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="229."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="234."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="230."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="235."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="231."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
-          <td class="diff-line-number" data-content="236."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="232."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
-          <td class="diff-line-number" data-content="237."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="233."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
-          <td class="diff-line-number" data-content="238."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="234."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
-          <td class="diff-line-number" data-content="239."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="235."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
-          <td class="diff-line-number" data-content="240."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="236."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
-          <td class="diff-line-number" data-content="241."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="237."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="242."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="238."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="243."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="239."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="244."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="240."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-removed">you’re using the DX service send to:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="245."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-inserted">you filed electronically but choose to pay by cheque, please send your payment, enclosing a payslip or quoting a &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; to avoid delay</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="241."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="242."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="243."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="244."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="245."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;Rapid Data Capture Centre</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="246."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;DX725593</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="247."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;Bootle 9</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="248."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="249."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="250."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="251."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="252."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="246."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="253."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="247."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="254."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="248."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="255."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
-          <td class="diff-line-number" data-content="249."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="256."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
-          <td class="diff-line-number" data-content="250."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="257."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
-          <td class="diff-line-number" data-content="251."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="258."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="252."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="259."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="253."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="260."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="254."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="261."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="255."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="262."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="256."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="263."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="257."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="264."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="258."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="265."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="259."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="266."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="260."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="267."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="261."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="268."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="262."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="269."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="263."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="270."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
-          <td class="diff-line-number" data-content="264."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="271."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
-          <td class="diff-line-number" data-content="265."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="272."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
-          <td class="diff-line-number" data-content="266."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="273."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
-          <td class="diff-line-number" data-content="267."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="274."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
-          <td class="diff-line-number" data-content="268."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="275."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="269."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="276."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
-          <td class="diff-line-number" data-content="270."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="277."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="271."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="278."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
-          <td class="diff-line-number" data-content="272."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="279."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
-          <td class="diff-line-number" data-content="273."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="280."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
-          <td class="diff-line-number" data-content="274."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="281."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
-          <td class="diff-line-number" data-content="275."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="282."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
-          <td class="diff-line-number" data-content="276."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="283."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
-          <td class="diff-line-number" data-content="277."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="284."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
-          <td class="diff-line-number" data-content="278."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="285."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
-          <td class="diff-line-number" data-content="279."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="286."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
-          <td class="diff-line-number" data-content="280."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="287."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
-          <td class="diff-line-number" data-content="281."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="288."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
-          <td class="diff-line-number" data-content="282."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="289."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
-          <td class="diff-line-number" data-content="283."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="290."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
-          <td class="diff-line-number" data-content="284."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="291."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
-          <td class="diff-line-number" data-content="285."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="292."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
-          <td class="diff-line-number" data-content="286."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="293."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="287."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="294."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
-          <td class="diff-line-number" data-content="288."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="295."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-removed">'2016-04-01T08:00:06.000+01:00'</span></td>
-          <td class="diff-line-number" data-content="289."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-inserted">'2016-07-27T10:49:59.000+01:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="296."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
-          <td class="diff-line-number" data-content="290."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="297."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
-          <td class="diff-line-number" data-content="291."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="298."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-          <td class="diff-line-number" data-content="292."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="299."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
-          <td class="diff-line-number" data-content="293."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="300."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-          <td class="diff-line-number" data-content="294."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="301."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
-          <td class="diff-line-number" data-content="295."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="302."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="296."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-        </tr>
-      </tbody>
-    </table>
+<div class="diff-checker">
+  <div class="diff-output">
+    <div class="diff-table-container" data-reactid="41">
+      <div class="diff-table-content" data-reactid="42">
+        <table class="diff-table" data-reactid="43">
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="1."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
+              <td class="diff-line-number" data-content="1."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="2."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
+              <td class="diff-line-number" data-content="2."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="3."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
+              <td class="diff-line-number" data-content="3."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="4."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
+              <td class="diff-line-number" data-content="4."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="5."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
+              <td class="diff-line-number" data-content="5."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="6."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
+              <td class="diff-line-number" data-content="6."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="7."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> </span><span class="diff-chunk diff-chunk-removed">How</span><span class="diff-chunk diff-chunk-equal"> to pay your Stamp Duty Land Tax (SDLT) and the time it </span><span class="diff-chunk diff-chunk-removed">takes for</span></td>
+              <td class="diff-line-number" data-content="7."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> </span><span class="diff-chunk diff-chunk-inserted">Find out how</span><span class="diff-chunk diff-chunk-equal"> to pay your Stamp Duty Land Tax (SDLT) and the time it </span><span class="diff-chunk diff-chunk-inserted">takes</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="8."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">  payment</span><span class="diff-chunk diff-chunk-equal"> to reach HM Revenue and Customs (HMRC).</span></td>
+              <td class="diff-line-number" data-content="8."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">  for payments</span><span class="diff-chunk diff-chunk-equal"> to reach HM Revenue and Customs (HMRC).</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="9."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
+              <td class="diff-line-number" data-content="9."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="10."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
+              <td class="diff-line-number" data-content="10."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="11."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="11."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="12."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="12."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="13."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a </span><span class="diff-chunk diff-chunk-equal">href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction </span><span class="diff-chunk diff-chunk-removed">Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="13."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a </span><span class="diff-chunk diff-chunk-inserted">rel="external" </span><span class="diff-chunk diff-chunk-equal">href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction </span><span class="diff-chunk diff-chunk-inserted">Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="14."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="15."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="14."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="16."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="15."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="17."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="16."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="18."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="17."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="19."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="18."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="20."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="19."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="21."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="20."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="22."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="21."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="23."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="22."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="24."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="23."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="25."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="24."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="26."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="25."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="27."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="26."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="28."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="27."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="29."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="28."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="30."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="29."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="31."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="30."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="32."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="31."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="33."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="32."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="34."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="33."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="35."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="34."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="36."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="35."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="37."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="36."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="38."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="37."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="39."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="38."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="40."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="39."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="41."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="40."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="42."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="41."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="43."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="42."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="44."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="43."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="45."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="44."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="46."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="45."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="47."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="46."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="48."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="47."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="49."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="48."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="50."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="49."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="51."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="50."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="52."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-chaps-bacs"&gt;Online</span><span class="diff-chunk diff-chunk-equal"> or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="51."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-chaps-and-bacs"&gt;Online</span><span class="diff-chunk diff-chunk-equal"> or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="53."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="52."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="54."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="53."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="55."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="54."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="56."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="55."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-chaps-and-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="57."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="56."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="58."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="57."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="59."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="58."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="60."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="59."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="61."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="60."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="62."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="61."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="63."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="62."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="64."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="63."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="65."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="64."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="66."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="65."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="67."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="66."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="68."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="67."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="69."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="68."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="70."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="69."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="71."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="70."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="72."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="71."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-chaps-and-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="73."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="72."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="74."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="73."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="75."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="74."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="76."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="75."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="77."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="76."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="78."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="77."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="79."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="78."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="80."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="79."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="81."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="80."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="82."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="81."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="83."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="82."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="84."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="83."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="85."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="84."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="86."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="85."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="87."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="86."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="88."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="87."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="89."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="88."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="90."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="89."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="91."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="90."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="92."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="91."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="93."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="92."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="94."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="93."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="95."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="94."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="96."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="95."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="97."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="96."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="98."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="97."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="99."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="98."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="100."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="99."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="101."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="100."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="102."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="101."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="103."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="102."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="104."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+              <td class="diff-line-number" data-content="103."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="105."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="104."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="106."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="105."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="107."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="106."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="108."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="107."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="109."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="108."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="110."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="109."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="111."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="110."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="112."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="111."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="113."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="112."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="114."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="113."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="115."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="114."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="116."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="115."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="117."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="116."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="118."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="117."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="119."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="118."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="120."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="119."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="121."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="120."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="122."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="121."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="123."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="122."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="124."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="123."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="125."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="124."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="126."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="125."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="127."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="126."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="128."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="127."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="129."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="128."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="130."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="129."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="131."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="130."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="132."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="131."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="133."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="132."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="134."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="133."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="135."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="134."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="136."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="135."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="137."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="136."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="138."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="137."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="139."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="138."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="140."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="139."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="141."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="140."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="142."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+              <td class="diff-line-number" data-content="141."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="143."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="142."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="144."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="143."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="145."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="144."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="146."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="145."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="147."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="146."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="148."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="147."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="149."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="148."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="150."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="149."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="151."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="150."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="152."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    Barclays Bank Plc</span></td>
+              <td class="diff-line-number" data-content="151."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    Barclays Bank Plc</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="153."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;1 Churchill Place</span></td>
+              <td class="diff-line-number" data-content="152."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;1 Churchill Place</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="154."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
+              <td class="diff-line-number" data-content="153."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="155."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;United Kingdom</span></td>
+              <td class="diff-line-number" data-content="154."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;United Kingdom</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="156."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 5HP</span></td>
+              <td class="diff-line-number" data-content="155."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 5HP</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="157."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="156."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="158."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="157."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="159."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="158."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="160."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="159."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="161."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="160."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="162."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="161."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="163."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="162."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="164."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;There is a fee for credit cards.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="163."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;There is a fee for credit cards.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="165."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="164."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="166."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="165."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="167."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="166."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="168."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="167."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="169."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="168."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="170."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="169."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="171."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="170."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="172."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to </span><span class="diff-chunk diff-chunk-removed">circumvent</span><span class="diff-chunk diff-chunk-equal"> this restriction.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="171."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to </span><span class="diff-chunk diff-chunk-inserted">get around</span><span class="diff-chunk diff-chunk-equal"> this restriction.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="173."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="172."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="174."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="173."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="175."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="174."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="176."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="175."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="177."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="176."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="178."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="177."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="179."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="178."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="180."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="179."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="181."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="180."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="182."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="181."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="183."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="182."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="184."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="183."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="185."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="184."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="186."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="185."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="187."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="186."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="188."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="187."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="189."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="188."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="190."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="189."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="191."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="190."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="192."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="191."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="193."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="192."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="194."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="193."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="195."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="194."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="196."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="195."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="197."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="196."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="198."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="197."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="199."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="198."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="200."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="199."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="201."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="200."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="202."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">&lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="201."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">&lt;p&gt;You can pay up to £10,000 at the Post Office without being charged using:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="203."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;You can pay at the Post Office by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="202."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="204."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="203."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="204."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">      &lt;li&gt;cheque (if accepted)&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="205."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">      &lt;li&gt;cash&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="206."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">      &lt;li&gt;debit card&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="207."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="208."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="209."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;p&gt;&lt;a rel="external" href="http://www.postoffice.co.uk/branch-finder"&gt;Contact your local Post Office branch&lt;/a&gt; to check if you can pay by cheque.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="205."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="210."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="206."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="211."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="207."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="212."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="208."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="213."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="209."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="214."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="210."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="215."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="211."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="216."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="212."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="217."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="213."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="218."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="214."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="219."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="215."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="220."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="216."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="221."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="217."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="222."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="218."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="223."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="219."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="224."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="220."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="225."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="221."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="226."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="222."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="227."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="223."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="228."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="224."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="229."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="225."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="230."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="226."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="231."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="227."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return </span><span class="diff-chunk diff-chunk-removed">or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your</span><span class="diff-chunk diff-chunk-equal"> payment to:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="232."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return </span><span class="diff-chunk diff-chunk-inserted">and wish to pay by cheque at the same time, please send your return and</span><span class="diff-chunk diff-chunk-equal"> payment to:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="228."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="233."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="229."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="234."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="230."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="235."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="231."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
+              <td class="diff-line-number" data-content="236."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="232."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
+              <td class="diff-line-number" data-content="237."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="233."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
+              <td class="diff-line-number" data-content="238."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="234."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
+              <td class="diff-line-number" data-content="239."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="235."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
+              <td class="diff-line-number" data-content="240."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="236."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
+              <td class="diff-line-number" data-content="241."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="237."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="242."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="238."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="243."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="239."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="244."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="240."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-removed">you’re using the DX service send to:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="245."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-inserted">you filed electronically but choose to pay by cheque, please send your payment, enclosing a payslip or quoting a &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; to avoid delay</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="241."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="242."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="243."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="244."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="245."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;Rapid Data Capture Centre</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="246."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;DX725593</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="247."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;Bootle 9</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="248."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="249."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="250."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="251."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="252."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="246."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="253."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="247."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="254."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="248."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="255."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
+              <td class="diff-line-number" data-content="249."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="256."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
+              <td class="diff-line-number" data-content="250."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="257."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
+              <td class="diff-line-number" data-content="251."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="258."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="252."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="259."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="253."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="260."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="254."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="261."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="255."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="262."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="256."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="263."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="257."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="264."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="258."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="265."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="259."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="266."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="260."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="267."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="261."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="268."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="262."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="269."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="263."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="270."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
+              <td class="diff-line-number" data-content="264."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="271."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
+              <td class="diff-line-number" data-content="265."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="272."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
+              <td class="diff-line-number" data-content="266."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="273."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
+              <td class="diff-line-number" data-content="267."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="274."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
+              <td class="diff-line-number" data-content="268."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="275."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="269."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="276."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
+              <td class="diff-line-number" data-content="270."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="277."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="271."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="278."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
+              <td class="diff-line-number" data-content="272."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="279."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
+              <td class="diff-line-number" data-content="273."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="280."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
+              <td class="diff-line-number" data-content="274."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="281."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
+              <td class="diff-line-number" data-content="275."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="282."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
+              <td class="diff-line-number" data-content="276."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="283."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
+              <td class="diff-line-number" data-content="277."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="284."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
+              <td class="diff-line-number" data-content="278."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="285."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
+              <td class="diff-line-number" data-content="279."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="286."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
+              <td class="diff-line-number" data-content="280."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="287."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
+              <td class="diff-line-number" data-content="281."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="288."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
+              <td class="diff-line-number" data-content="282."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="289."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
+              <td class="diff-line-number" data-content="283."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="290."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
+              <td class="diff-line-number" data-content="284."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="291."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
+              <td class="diff-line-number" data-content="285."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="292."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
+              <td class="diff-line-number" data-content="286."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="293."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="287."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="294."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
+              <td class="diff-line-number" data-content="288."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="295."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-removed">'2016-04-01T08:00:06.000+01:00'</span></td>
+              <td class="diff-line-number" data-content="289."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-inserted">'2016-07-27T10:49:59.000+01:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="296."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
+              <td class="diff-line-number" data-content="290."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="297."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
+              <td class="diff-line-number" data-content="291."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="298."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+              <td class="diff-line-number" data-content="292."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="299."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
+              <td class="diff-line-number" data-content="293."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="300."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+              <td class="diff-line-number" data-content="294."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="301."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
+              <td class="diff-line-number" data-content="295."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="302."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="296."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
 </div>

--- a/historical-frontend/v3-v4.html
+++ b/historical-frontend/v3-v4.html
@@ -1547,7 +1547,7 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
               <td class="diff-line-number" data-content="240."></td>
               <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-removed">you’re using the DX service send to:&lt;/p&gt;</span></td>
               <td class="diff-line-number" data-content="245."></td>
-              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-inserted">you filed electronically but choose to pay by cheque, please send your payment, enclosing a payslip or quoting a &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; to avoid delay</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-inserted">you filed electronically but choose to pay by cheque, please send your payment, enclosing a payslip or quoting a &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; to avoid delay</span><span class="diff-chunk diff-chunk-equal"> to:&lt;/p&gt;</span></td>
             </tr>
             <tr class="diff-row">
               <td class="diff-line-number" data-content="241."></td>
@@ -1611,7 +1611,7 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
             </tr>
             <tr class="diff-row">
               <td class="diff-line-number" data-content="251."></td>
-              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque</span><span class="diff-chunk diff-chunk-equal"> to:&lt;/p&gt;</span></td>
               <td class="diff-line-number" data-content=""></td>
               <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
             </tr>

--- a/historical-frontend/v4-v1.html
+++ b/historical-frontend/v4-v1.html
@@ -1602,7 +1602,7 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
             </tr>
             <tr class="diff-row">
               <td class="diff-line-number" data-content="245."></td>
-              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-removed">you filed electronically but choose to pay by cheque, please send your payment, enclosing a payslip or quoting a &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; to avoid delay</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-removed">you filed electronically but choose to pay by cheque, please send your payment, enclosing a payslip or quoting a &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; to avoid delay</span><span class="diff-chunk diff-chunk-equal"> to:&lt;/p&gt;</span></td>
               <td class="diff-line-number" data-content="245."></td>
               <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-inserted">you’re using the DX service send to:&lt;/p&gt;</span></td>
             </tr>
@@ -1670,7 +1670,7 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
               <td class="diff-line-number" data-content=""></td>
               <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
               <td class="diff-line-number" data-content="256."></td>
-              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque</span><span class="diff-chunk diff-chunk-equal"> to:&lt;/p&gt;</span></td>
             </tr>
             <tr class="diff-row">
               <td class="diff-line-number" data-content="246."></td>

--- a/historical-frontend/v4-v1.html
+++ b/historical-frontend/v4-v1.html
@@ -4,7 +4,7 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
 ---
 
 {% include_relative _heading.html %}
-{% include_relative _select.html from="v4" to="v1" %}
+{% include_relative _compare.html from=4 to=1 %}
 
 <div class="diff-checker">
   <div class="diff-output">

--- a/historical-frontend/v4-v1.html
+++ b/historical-frontend/v4-v1.html
@@ -6,1989 +6,1993 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
 {% include_relative _heading.html %}
 {% include_relative _select.html from="v4" to="v1" %}
 
-<div class="diff-table-container" data-reactid="41">
-  <div class="diff-table-content" data-reactid="42">
-    <table class="diff-table" data-reactid="43">
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="1."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
-          <td class="diff-line-number" data-content="1."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="2."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
-          <td class="diff-line-number" data-content="2."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="3."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
-          <td class="diff-line-number" data-content="3."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="4."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
-          <td class="diff-line-number" data-content="4."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="5."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
-          <td class="diff-line-number" data-content="5."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="6."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
-          <td class="diff-line-number" data-content="6."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="7."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> </span><span class="diff-chunk diff-chunk-removed">Find out how</span><span class="diff-chunk diff-chunk-equal"> to pay your Stamp Duty Land Tax (SDLT) and the time it </span><span class="diff-chunk diff-chunk-removed">takes</span></td>
-          <td class="diff-line-number" data-content="7."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> </span><span class="diff-chunk diff-chunk-inserted">How</span><span class="diff-chunk diff-chunk-equal"> to pay your Stamp Duty Land Tax (SDLT) and the time it </span><span class="diff-chunk diff-chunk-inserted">takes for</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="8."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">  for payments</span><span class="diff-chunk diff-chunk-equal"> to reach HM Revenue and Customs (HMRC).</span></td>
-          <td class="diff-line-number" data-content="8."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">  payment</span><span class="diff-chunk diff-chunk-equal"> to reach HM Revenue and Customs (HMRC).</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="9."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
-          <td class="diff-line-number" data-content="9."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="10."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
-          <td class="diff-line-number" data-content="10."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="11."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="11."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="12."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
-          <td class="diff-line-number" data-content="12."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="13."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a </span><span class="diff-chunk diff-chunk-removed">rel="external" </span><span class="diff-chunk diff-chunk-equal">href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction </span><span class="diff-chunk diff-chunk-removed">Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="13."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a </span><span class="diff-chunk diff-chunk-equal">href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction </span><span class="diff-chunk diff-chunk-inserted">Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="14."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="14."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="15."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="15."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="16."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="16."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="17."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="17."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="18."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="18."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="19."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="19."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="20."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="20."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="21."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="21."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="22."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="22."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="23."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="23."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="24."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="24."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="25."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="25."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="26."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="26."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="27."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="27."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="28."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="28."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="29."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="29."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="30."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="30."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="31."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="31."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="32."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="32."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="33."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="33."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="34."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="34."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="35."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="35."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="36."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="36."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="37."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="37."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="38."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="38."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="39."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="39."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="40."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="40."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="41."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="41."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="42."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="42."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="43."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="43."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="44."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="44."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="45."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="45."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="46."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="46."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="47."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="47."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="48."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="48."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="49."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="49."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="50."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="50."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="51."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="51."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-chaps-and-bacs"&gt;Online</span><span class="diff-chunk diff-chunk-equal"> or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="52."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-chaps-bacs"&gt;Online</span><span class="diff-chunk diff-chunk-equal"> or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="52."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="53."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="53."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="54."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="54."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="55."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="55."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-chaps-and-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="56."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="56."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="57."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="57."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="58."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="58."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="59."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="59."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="60."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="60."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="61."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="61."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="62."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="62."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="63."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="63."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="64."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="64."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="65."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="65."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="66."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="66."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="67."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="67."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="68."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="68."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="69."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="69."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="70."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="70."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="71."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="71."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-chaps-and-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="72."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="72."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="73."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="73."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="74."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="74."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="75."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="75."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="76."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="76."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="77."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="77."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="78."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="78."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="79."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="79."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="80."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="80."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="81."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="81."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="82."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="82."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="83."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="83."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="84."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="84."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="85."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="85."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="86."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="86."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="87."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="87."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="88."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="88."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="89."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="89."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="90."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="90."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="91."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="91."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="92."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="92."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="93."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="93."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="94."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="94."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="95."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="95."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="96."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="96."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="97."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="97."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="98."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="98."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="99."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="99."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="100."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="100."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="101."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="101."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="102."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="102."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="103."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="103."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-          <td class="diff-line-number" data-content="104."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="104."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="105."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="105."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="106."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="106."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="107."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="107."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="108."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="108."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="109."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="109."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="110."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="110."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="111."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="111."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="112."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="112."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="113."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="113."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="114."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="114."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="115."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="115."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="116."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="116."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="117."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="117."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="118."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="118."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="119."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="119."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="120."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="120."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="121."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="121."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="122."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="122."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="123."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="123."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="124."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="124."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="125."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="125."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="126."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="126."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="127."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="127."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="128."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="128."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="129."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="129."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="130."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="130."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="131."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="131."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="132."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="132."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="133."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="133."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="134."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="134."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="135."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="135."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="136."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="136."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="137."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="137."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="138."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="138."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="139."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="139."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-removed">&lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="140."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-inserted">&lt;td&gt;GB05CITI08321012001020&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="140."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-removed">&lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="141."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-inserted">&lt;td&gt;CITIGB2L&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="141."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-          <td class="diff-line-number" data-content="142."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="142."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="143."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="143."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="144."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="144."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="145."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="145."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="146."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="146."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="147."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="147."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="148."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="148."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="149."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="149."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="150."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="150."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="151."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="151."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">Barclays Bank Plc</span></td>
-          <td class="diff-line-number" data-content="152."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">Citibank N A</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="152."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;1 Churchill Place</span></td>
-          <td class="diff-line-number" data-content="153."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;Citigroup Centre</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="154."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;Canary Wharf 33</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="155."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;Canada Square</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="153."></td>
-          <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
-          <td class="diff-line-number" data-content="156."></td>
-          <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="154."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;United Kingdom</span></td>
-          <td class="diff-line-number" data-content="157."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-inserted">5LB</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="155."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-removed">5HP</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="156."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="158."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="157."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="159."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="158."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="160."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="159."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="161."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="160."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="162."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="161."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="163."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="162."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="164."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="163."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">&lt;p&gt;There is a fee for credit cards.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="165."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">&lt;p&gt;You’ll pay a 1.5% fee if you use a credit card. The fee isn’t refundable.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="166."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="167."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="168."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;p&gt;You may be directed to use a &lt;a href="https://www.gov.uk/help/beta"&gt;beta&lt;/a&gt; service when you pay online. This is replacing BillPay.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="169."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="164."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="170."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="165."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="171."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="166."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="172."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="167."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="173."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="168."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="174."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="169."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="175."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="170."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="176."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="171."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to </span><span class="diff-chunk diff-chunk-removed">get around</span><span class="diff-chunk diff-chunk-equal"> this restriction.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="177."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to </span><span class="diff-chunk diff-chunk-inserted">circumvent</span><span class="diff-chunk diff-chunk-equal"> this restriction.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="172."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="178."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="173."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="179."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="174."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="180."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="175."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="181."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="176."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="182."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="177."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="183."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="178."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="184."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="179."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="185."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="180."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="186."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="181."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="187."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="182."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="188."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="183."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="189."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="184."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="190."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="185."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="191."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="186."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="192."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="187."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="193."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="188."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="194."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="189."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="195."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="190."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="196."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="191."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="197."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="192."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="198."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="193."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="199."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="194."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="200."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="195."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="201."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="196."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="202."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="197."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="203."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="198."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="204."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="199."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="205."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="200."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="206."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="201."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay </span><span class="diff-chunk diff-chunk-removed">up to £10,000 </span><span class="diff-chunk diff-chunk-equal">at the Post Office </span><span class="diff-chunk diff-chunk-removed">without being charged using:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="207."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="202."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
-          <td class="diff-line-number" data-content="208."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay </span><span class="diff-chunk diff-chunk-equal">at the Post Office </span><span class="diff-chunk diff-chunk-inserted">by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="203."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="209."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="204."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">      &lt;li&gt;cheque (if accepted)&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="205."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">      &lt;li&gt;cash&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="206."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">      &lt;li&gt;debit card&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="207."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="208."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="209."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;&lt;a rel="external" href="http://www.postoffice.co.uk/branch-finder"&gt;Contact your local Post Office branch&lt;/a&gt; to check if you can pay by cheque.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="210."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="210."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="211."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="211."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="212."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="212."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="213."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="213."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="214."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="214."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="215."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="215."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="216."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="216."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="217."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="217."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="218."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="218."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="219."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="219."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="220."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="220."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="221."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="221."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="222."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="222."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="223."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="223."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="224."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="224."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="225."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="225."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="226."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="226."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="227."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="227."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="228."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="228."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="229."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="229."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="230."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="230."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="231."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="231."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="232."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return </span><span class="diff-chunk diff-chunk-removed">and wish to pay by cheque at the same time, please send your return and</span><span class="diff-chunk diff-chunk-equal"> payment to:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="232."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return </span><span class="diff-chunk diff-chunk-inserted">or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your</span><span class="diff-chunk diff-chunk-equal"> payment to:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="233."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="233."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="234."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="234."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="235."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="235."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="236."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
-          <td class="diff-line-number" data-content="236."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="237."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
-          <td class="diff-line-number" data-content="237."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="238."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
-          <td class="diff-line-number" data-content="238."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="239."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
-          <td class="diff-line-number" data-content="239."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="240."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
-          <td class="diff-line-number" data-content="240."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="241."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
-          <td class="diff-line-number" data-content="241."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="242."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="242."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="243."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="243."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="244."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="244."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="245."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-removed">you filed electronically but choose to pay by cheque, please send your payment, enclosing a payslip or quoting a &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; to avoid delay</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="245."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-inserted">you’re using the DX service send to:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="246."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="247."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="248."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="249."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="250."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;Rapid Data Capture Centre</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="251."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;DX725593</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="252."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;Bootle 9</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="253."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="254."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="255."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="256."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="246."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="257."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="247."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="258."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="248."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="259."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="249."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
-          <td class="diff-line-number" data-content="260."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="250."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
-          <td class="diff-line-number" data-content="261."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="251."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
-          <td class="diff-line-number" data-content="262."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="252."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="263."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="253."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="264."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="254."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="265."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="255."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="266."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="256."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="267."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="257."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="268."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="258."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="269."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="259."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="270."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="260."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="271."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="261."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="272."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="262."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="273."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="263."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="274."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="264."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
-          <td class="diff-line-number" data-content="275."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="265."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
-          <td class="diff-line-number" data-content="276."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="266."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
-          <td class="diff-line-number" data-content="277."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="267."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
-          <td class="diff-line-number" data-content="278."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="268."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
-          <td class="diff-line-number" data-content="279."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="269."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="280."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="270."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
-          <td class="diff-line-number" data-content="281."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="271."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="282."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="272."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
-          <td class="diff-line-number" data-content="283."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="273."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
-          <td class="diff-line-number" data-content="284."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="274."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
-          <td class="diff-line-number" data-content="285."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="275."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
-          <td class="diff-line-number" data-content="286."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="276."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
-          <td class="diff-line-number" data-content="287."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="277."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
-          <td class="diff-line-number" data-content="288."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="278."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
-          <td class="diff-line-number" data-content="289."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="279."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
-          <td class="diff-line-number" data-content="290."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="280."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
-          <td class="diff-line-number" data-content="291."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="281."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
-          <td class="diff-line-number" data-content="292."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="282."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
-          <td class="diff-line-number" data-content="293."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="283."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
-          <td class="diff-line-number" data-content="294."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="284."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
-          <td class="diff-line-number" data-content="295."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="285."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
-          <td class="diff-line-number" data-content="296."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="286."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
-          <td class="diff-line-number" data-content="297."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="287."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="298."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="288."></td>
-          <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
-          <td class="diff-line-number" data-content="299."></td>
-          <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="289."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-removed">'2016-07-27T10:49:59.000+01:00'</span></td>
-          <td class="diff-line-number" data-content="300."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-inserted">'2015-12-02T14:31:42.000+00:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="290."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
-          <td class="diff-line-number" data-content="301."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="291."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
-          <td class="diff-line-number" data-content="302."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="292."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-          <td class="diff-line-number" data-content="303."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="293."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
-          <td class="diff-line-number" data-content="304."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="294."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-          <td class="diff-line-number" data-content="305."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="295."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
-          <td class="diff-line-number" data-content="306."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="296."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="307."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
-        </tr>
-      </tbody>
-    </table>
+<div class="diff-checker">
+  <div class="diff-output">
+    <div class="diff-table-container" data-reactid="41">
+      <div class="diff-table-content" data-reactid="42">
+        <table class="diff-table" data-reactid="43">
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="1."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
+              <td class="diff-line-number" data-content="1."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="2."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
+              <td class="diff-line-number" data-content="2."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="3."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
+              <td class="diff-line-number" data-content="3."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="4."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
+              <td class="diff-line-number" data-content="4."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="5."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
+              <td class="diff-line-number" data-content="5."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="6."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
+              <td class="diff-line-number" data-content="6."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="7."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> </span><span class="diff-chunk diff-chunk-removed">Find out how</span><span class="diff-chunk diff-chunk-equal"> to pay your Stamp Duty Land Tax (SDLT) and the time it </span><span class="diff-chunk diff-chunk-removed">takes</span></td>
+              <td class="diff-line-number" data-content="7."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> </span><span class="diff-chunk diff-chunk-inserted">How</span><span class="diff-chunk diff-chunk-equal"> to pay your Stamp Duty Land Tax (SDLT) and the time it </span><span class="diff-chunk diff-chunk-inserted">takes for</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="8."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">  for payments</span><span class="diff-chunk diff-chunk-equal"> to reach HM Revenue and Customs (HMRC).</span></td>
+              <td class="diff-line-number" data-content="8."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">  payment</span><span class="diff-chunk diff-chunk-equal"> to reach HM Revenue and Customs (HMRC).</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="9."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
+              <td class="diff-line-number" data-content="9."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="10."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
+              <td class="diff-line-number" data-content="10."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="11."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="11."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="12."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
+              <td class="diff-line-number" data-content="12."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="13."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a </span><span class="diff-chunk diff-chunk-removed">rel="external" </span><span class="diff-chunk diff-chunk-equal">href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction </span><span class="diff-chunk diff-chunk-removed">Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="13."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a </span><span class="diff-chunk diff-chunk-equal">href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction </span><span class="diff-chunk diff-chunk-inserted">Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="14."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="14."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="15."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="15."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="16."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="16."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="17."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="17."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="18."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="18."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="19."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="19."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="20."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="20."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="21."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="21."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="22."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="22."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="23."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="23."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="24."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="24."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="25."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="25."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="26."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="26."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="27."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="27."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="28."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="28."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="29."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="29."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="30."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="30."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="31."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="31."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="32."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="32."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="33."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="33."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="34."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="34."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="35."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="35."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="36."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="36."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="37."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="37."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="38."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="38."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="39."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="39."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="40."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="40."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="41."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="41."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="42."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="42."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="43."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="43."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="44."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="44."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="45."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="45."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="46."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="46."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="47."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="47."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="48."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="48."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="49."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="49."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="50."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="50."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="51."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="51."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-chaps-and-bacs"&gt;Online</span><span class="diff-chunk diff-chunk-equal"> or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="52."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-chaps-bacs"&gt;Online</span><span class="diff-chunk diff-chunk-equal"> or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="52."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="53."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="53."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="54."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="54."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="55."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="55."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-chaps-and-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="56."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="56."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="57."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="57."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="58."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="58."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="59."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="59."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="60."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="60."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="61."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="61."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="62."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="62."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="63."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="63."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="64."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="64."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="65."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="65."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="66."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="66."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="67."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="67."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="68."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="68."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="69."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="69."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="70."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="70."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="71."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="71."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-chaps-and-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="72."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="72."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="73."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="73."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="74."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="74."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="75."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="75."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="76."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="76."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="77."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="77."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="78."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="78."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="79."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="79."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="80."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="80."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="81."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="81."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="82."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="82."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="83."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="83."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="84."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="84."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="85."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="85."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="86."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="86."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="87."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="87."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="88."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="88."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="89."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="89."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="90."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="90."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="91."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="91."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="92."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="92."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="93."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="93."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="94."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="94."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="95."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="95."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="96."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="96."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="97."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="97."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="98."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="98."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="99."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="99."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="100."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="100."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="101."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="101."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="102."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="102."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="103."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="103."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+              <td class="diff-line-number" data-content="104."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="104."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="105."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="105."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="106."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="106."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="107."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="107."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="108."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="108."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="109."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="109."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="110."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="110."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="111."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="111."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="112."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="112."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="113."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="113."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="114."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="114."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="115."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="115."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="116."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="116."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="117."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="117."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="118."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="118."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="119."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="119."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="120."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="120."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="121."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="121."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="122."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="122."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="123."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="123."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="124."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="124."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="125."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="125."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="126."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="126."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="127."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="127."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="128."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="128."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="129."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="129."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="130."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="130."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="131."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="131."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="132."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="132."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="133."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="133."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="134."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="134."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="135."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="135."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="136."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="136."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="137."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="137."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="138."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="138."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="139."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="139."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-removed">&lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="140."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-inserted">&lt;td&gt;GB05CITI08321012001020&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="140."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-removed">&lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="141."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span><span class="diff-chunk diff-chunk-equal">          </span><span class="diff-chunk diff-chunk-inserted">&lt;td&gt;CITIGB2L&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="141."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+              <td class="diff-line-number" data-content="142."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="142."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="143."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="143."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="144."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="144."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="145."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="145."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="146."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="146."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="147."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="147."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="148."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="148."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="149."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="149."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="150."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="150."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="151."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="151."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">Barclays Bank Plc</span></td>
+              <td class="diff-line-number" data-content="152."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">Citibank N A</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="152."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;1 Churchill Place</span></td>
+              <td class="diff-line-number" data-content="153."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;Citigroup Centre</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="154."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;Canary Wharf 33</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="155."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;Canada Square</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="153."></td>
+              <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
+              <td class="diff-line-number" data-content="156."></td>
+              <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="154."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;br&gt;United Kingdom</span></td>
+              <td class="diff-line-number" data-content="157."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-inserted">5LB</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="155."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-removed">5HP</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="156."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="158."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="157."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="159."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="158."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="160."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="159."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="161."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="160."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="162."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="161."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="163."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="162."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="164."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="163."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">&lt;p&gt;There is a fee for credit cards.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="165."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">&lt;p&gt;You’ll pay a 1.5% fee if you use a credit card. The fee isn’t refundable.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="166."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="167."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="168."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;p&gt;You may be directed to use a &lt;a href="https://www.gov.uk/help/beta"&gt;beta&lt;/a&gt; service when you pay online. This is replacing BillPay.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="169."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="164."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="170."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="165."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="171."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="166."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="172."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="167."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="173."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="168."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="174."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="169."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="175."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="170."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="176."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="171."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to </span><span class="diff-chunk diff-chunk-removed">get around</span><span class="diff-chunk diff-chunk-equal"> this restriction.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="177."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to </span><span class="diff-chunk diff-chunk-inserted">circumvent</span><span class="diff-chunk diff-chunk-equal"> this restriction.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="172."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="178."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="173."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="179."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="174."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="180."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="175."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="181."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="176."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="182."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="177."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="183."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="178."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="184."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="179."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="185."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="180."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="186."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="181."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="187."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="182."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="188."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="183."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="189."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="184."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="190."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="185."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="191."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="186."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="192."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="187."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="193."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="188."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="194."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="189."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="195."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="190."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="196."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="191."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="197."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="192."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="198."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="193."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="199."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="194."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="200."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="195."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="201."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="196."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="202."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="197."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="203."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="198."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="204."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="199."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="205."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="200."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="206."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="201."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay </span><span class="diff-chunk diff-chunk-removed">up to £10,000 </span><span class="diff-chunk diff-chunk-equal">at the Post Office </span><span class="diff-chunk diff-chunk-removed">without being charged using:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="207."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="202."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
+              <td class="diff-line-number" data-content="208."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay </span><span class="diff-chunk diff-chunk-equal">at the Post Office </span><span class="diff-chunk diff-chunk-inserted">by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="203."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="209."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="204."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">      &lt;li&gt;cheque (if accepted)&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="205."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">      &lt;li&gt;cash&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="206."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">      &lt;li&gt;debit card&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="207."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="208."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="209."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;&lt;a rel="external" href="http://www.postoffice.co.uk/branch-finder"&gt;Contact your local Post Office branch&lt;/a&gt; to check if you can pay by cheque.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="210."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="210."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="211."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="211."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="212."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="212."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="213."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="213."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="214."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="214."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="215."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="215."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="216."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="216."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="217."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="217."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="218."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="218."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="219."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="219."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="220."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="220."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="221."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="221."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="222."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="222."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="223."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="223."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="224."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="224."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="225."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="225."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="226."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="226."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="227."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="227."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="228."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="228."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="229."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="229."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="230."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="230."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="231."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="231."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="232."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return </span><span class="diff-chunk diff-chunk-removed">and wish to pay by cheque at the same time, please send your return and</span><span class="diff-chunk diff-chunk-equal"> payment to:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="232."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return </span><span class="diff-chunk diff-chunk-inserted">or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your</span><span class="diff-chunk diff-chunk-equal"> payment to:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="233."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="233."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="234."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="234."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="235."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="235."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="236."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
+              <td class="diff-line-number" data-content="236."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="237."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
+              <td class="diff-line-number" data-content="237."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="238."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
+              <td class="diff-line-number" data-content="238."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="239."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
+              <td class="diff-line-number" data-content="239."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="240."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
+              <td class="diff-line-number" data-content="240."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="241."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
+              <td class="diff-line-number" data-content="241."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="242."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="242."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="243."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="243."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="244."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="244."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="245."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-removed">you filed electronically but choose to pay by cheque, please send your payment, enclosing a payslip or quoting a &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; to avoid delay</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="245."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-inserted">you’re using the DX service send to:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="246."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="247."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="248."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="249."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="250."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;Rapid Data Capture Centre</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="251."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;DX725593</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="252."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;Bootle 9</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="253."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="254."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="255."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="256."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="246."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="257."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="247."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="258."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="248."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="259."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="249."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
+              <td class="diff-line-number" data-content="260."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="250."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
+              <td class="diff-line-number" data-content="261."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="251."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
+              <td class="diff-line-number" data-content="262."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="252."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="263."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="253."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="264."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="254."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="265."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="255."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="266."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="256."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="267."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="257."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="268."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="258."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="269."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="259."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="270."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="260."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="271."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="261."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="272."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="262."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="273."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="263."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="274."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="264."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
+              <td class="diff-line-number" data-content="275."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="265."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
+              <td class="diff-line-number" data-content="276."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="266."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
+              <td class="diff-line-number" data-content="277."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="267."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
+              <td class="diff-line-number" data-content="278."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="268."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
+              <td class="diff-line-number" data-content="279."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="269."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="280."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="270."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
+              <td class="diff-line-number" data-content="281."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="271."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="282."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="272."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
+              <td class="diff-line-number" data-content="283."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="273."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
+              <td class="diff-line-number" data-content="284."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="274."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
+              <td class="diff-line-number" data-content="285."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="275."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
+              <td class="diff-line-number" data-content="286."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="276."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
+              <td class="diff-line-number" data-content="287."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="277."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
+              <td class="diff-line-number" data-content="288."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="278."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
+              <td class="diff-line-number" data-content="289."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="279."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
+              <td class="diff-line-number" data-content="290."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="280."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
+              <td class="diff-line-number" data-content="291."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="281."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
+              <td class="diff-line-number" data-content="292."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="282."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
+              <td class="diff-line-number" data-content="293."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="283."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
+              <td class="diff-line-number" data-content="294."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="284."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
+              <td class="diff-line-number" data-content="295."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="285."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
+              <td class="diff-line-number" data-content="296."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="286."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
+              <td class="diff-line-number" data-content="297."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="287."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="298."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="288."></td>
+              <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
+              <td class="diff-line-number" data-content="299."></td>
+              <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="289."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-removed">'2016-07-27T10:49:59.000+01:00'</span></td>
+              <td class="diff-line-number" data-content="300."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-inserted">'2015-12-02T14:31:42.000+00:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="290."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
+              <td class="diff-line-number" data-content="301."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="291."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
+              <td class="diff-line-number" data-content="302."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="292."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+              <td class="diff-line-number" data-content="303."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="293."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
+              <td class="diff-line-number" data-content="304."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="294."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+              <td class="diff-line-number" data-content="305."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="295."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
+              <td class="diff-line-number" data-content="306."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="296."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="307."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
 </div>

--- a/historical-frontend/v4-v2.html
+++ b/historical-frontend/v4-v2.html
@@ -4,7 +4,7 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
 ---
 
 {% include_relative _heading.html %}
-{% include_relative _select.html from="v4" to="v2" %}
+{% include_relative _compare.html from=4 to=2 %}
 
 <div class="diff-checker">
   <div class="diff-output">

--- a/historical-frontend/v4-v2.html
+++ b/historical-frontend/v4-v2.html
@@ -1583,7 +1583,7 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
             </tr>
             <tr class="diff-row">
               <td class="diff-line-number" data-content="245."></td>
-              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-removed">you filed electronically but choose to pay by cheque, please send your payment, enclosing a payslip or quoting a &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; to avoid delay</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-removed">you filed electronically but choose to pay by cheque, please send your payment, enclosing a payslip or quoting a &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; to avoid delay</span><span class="diff-chunk diff-chunk-equal"> to:&lt;/p&gt;</span></td>
               <td class="diff-line-number" data-content="244."></td>
               <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-inserted">you’re using the DX service send to:&lt;/p&gt;</span></td>
             </tr>
@@ -1651,7 +1651,7 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
               <td class="diff-line-number" data-content=""></td>
               <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
               <td class="diff-line-number" data-content="255."></td>
-              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque</span><span class="diff-chunk diff-chunk-equal"> to:&lt;/p&gt;</span></td>
             </tr>
             <tr class="diff-row">
               <td class="diff-line-number" data-content="246."></td>

--- a/historical-frontend/v4-v2.html
+++ b/historical-frontend/v4-v2.html
@@ -6,1970 +6,1974 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
 {% include_relative _heading.html %}
 {% include_relative _select.html from="v4" to="v2" %}
 
-<div class="diff-table-container" data-reactid="41">
-  <div class="diff-table-content" data-reactid="42">
-    <table class="diff-table" data-reactid="43">
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="1."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
-          <td class="diff-line-number" data-content="1."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="2."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
-          <td class="diff-line-number" data-content="2."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="3."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
-          <td class="diff-line-number" data-content="3."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="4."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
-          <td class="diff-line-number" data-content="4."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="5."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
-          <td class="diff-line-number" data-content="5."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="6."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
-          <td class="diff-line-number" data-content="6."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="7."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> </span><span class="diff-chunk diff-chunk-removed">Find out how</span><span class="diff-chunk diff-chunk-equal"> to pay your Stamp Duty Land Tax (SDLT) and the time it </span><span class="diff-chunk diff-chunk-removed">takes</span></td>
-          <td class="diff-line-number" data-content="7."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> </span><span class="diff-chunk diff-chunk-inserted">How</span><span class="diff-chunk diff-chunk-equal"> to pay your Stamp Duty Land Tax (SDLT) and the time it </span><span class="diff-chunk diff-chunk-inserted">takes for</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="8."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">  for payments</span><span class="diff-chunk diff-chunk-equal"> to reach HM Revenue and Customs (HMRC).</span></td>
-          <td class="diff-line-number" data-content="8."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">  payment</span><span class="diff-chunk diff-chunk-equal"> to reach HM Revenue and Customs (HMRC).</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="9."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
-          <td class="diff-line-number" data-content="9."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="10."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
-          <td class="diff-line-number" data-content="10."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="11."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="11."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="12."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
-          <td class="diff-line-number" data-content="12."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="13."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a </span><span class="diff-chunk diff-chunk-removed">rel="external" </span><span class="diff-chunk diff-chunk-equal">href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction </span><span class="diff-chunk diff-chunk-removed">Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="13."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a </span><span class="diff-chunk diff-chunk-equal">href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction </span><span class="diff-chunk diff-chunk-inserted">Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="14."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="14."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="15."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="15."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="16."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="16."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="17."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="17."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="18."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="18."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="19."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="19."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="20."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="20."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="21."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="21."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="22."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="22."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="23."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="23."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="24."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="24."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="25."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="25."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="26."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="26."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="27."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="27."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="28."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="28."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="29."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="29."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="30."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="30."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="31."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="31."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="32."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="32."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="33."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="33."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="34."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="34."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="35."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="35."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="36."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="36."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="37."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="37."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="38."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="38."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="39."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="39."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="40."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="40."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="41."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="41."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="42."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="42."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="43."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="43."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="44."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="44."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="45."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="45."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="46."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="46."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="47."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="47."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="48."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="48."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="49."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="49."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="50."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="50."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="51."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="51."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-chaps-and-bacs"&gt;Online</span><span class="diff-chunk diff-chunk-equal"> or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="52."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-chaps-bacs"&gt;Online</span><span class="diff-chunk diff-chunk-equal"> or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="52."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="53."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="53."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="54."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="54."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="55."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="55."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-chaps-and-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="56."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="56."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="57."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="57."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="58."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="58."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="59."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="59."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="60."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="60."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="61."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="61."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="62."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="62."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="63."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="63."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="64."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="64."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="65."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="65."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="66."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="66."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="67."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="67."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="68."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="68."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="69."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="69."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="70."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="70."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="71."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="71."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-chaps-and-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="72."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="72."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="73."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="73."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="74."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="74."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="75."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="75."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="76."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="76."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="77."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="77."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="78."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="78."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="79."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="79."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="80."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="80."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="81."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="81."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="82."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="82."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="83."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="83."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="84."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="84."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="85."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="85."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="86."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="86."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="87."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="87."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="88."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="88."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="89."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="89."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="90."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="90."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="91."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="91."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="92."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="92."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="93."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="93."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="94."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="94."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="95."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="95."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="96."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="96."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="97."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="97."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="98."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="98."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="99."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="99."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="100."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="100."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="101."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="101."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="102."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="102."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="103."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="103."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-          <td class="diff-line-number" data-content="104."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="104."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="105."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="105."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="106."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="106."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="107."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="107."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="108."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="108."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="109."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="109."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="110."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="110."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="111."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="111."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="112."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="112."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="113."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="113."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="114."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="114."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="115."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="115."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="116."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="116."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="117."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="117."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="118."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="118."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="119."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="119."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="120."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="120."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="121."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="121."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="122."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="122."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="123."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="123."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="124."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="124."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="125."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="125."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="126."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="126."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="127."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="127."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="128."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="128."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="129."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="129."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="130."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="130."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="131."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="131."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="132."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="132."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="133."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="133."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="134."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="134."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="135."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="135."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="136."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="136."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="137."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="137."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="138."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="138."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="139."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="139."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="140."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="140."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="141."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="141."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-          <td class="diff-line-number" data-content="142."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="142."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="143."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="143."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="144."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="144."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="145."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="145."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="146."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="146."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="147."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="147."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="148."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="148."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="149."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="149."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="150."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="150."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="151."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="151."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    Barclays Bank Plc</span></td>
-          <td class="diff-line-number" data-content="152."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    Barclays Bank Plc</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="152."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;1 Churchill Place</span></td>
-          <td class="diff-line-number" data-content="153."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;1 Churchill Place</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="153."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
-          <td class="diff-line-number" data-content="154."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="154."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;United Kingdom</span></td>
-          <td class="diff-line-number" data-content="155."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;United Kingdom</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="155."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-removed">5HP</span></td>
-          <td class="diff-line-number" data-content="156."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-inserted">5HO</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="156."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="157."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="157."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="158."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="158."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="159."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="159."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="160."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="160."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="161."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="161."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="162."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="162."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="163."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="163."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">&lt;p&gt;There is a fee for credit cards.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="164."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">&lt;p&gt;You’ll pay a 1.5% fee if you use a credit card. The fee isn’t refundable.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="165."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="166."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="167."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;p&gt;You may be directed to use a &lt;a href="https://www.gov.uk/help/beta"&gt;beta&lt;/a&gt; service when you pay online. This is replacing BillPay.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="168."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="164."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="169."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="165."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="170."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="166."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="171."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="167."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="172."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="168."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="173."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="169."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="174."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="170."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="175."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="171."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to </span><span class="diff-chunk diff-chunk-removed">get around</span><span class="diff-chunk diff-chunk-equal"> this restriction.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="176."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to </span><span class="diff-chunk diff-chunk-inserted">circumvent</span><span class="diff-chunk diff-chunk-equal"> this restriction.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="172."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="177."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="173."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="178."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="174."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="179."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="175."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="180."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="176."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="181."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="177."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="182."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="178."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="183."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="179."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="184."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="180."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="185."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="181."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="186."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="182."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="187."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="183."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="188."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="184."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="189."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="185."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="190."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="186."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="191."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="187."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="192."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="188."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="193."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="189."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="194."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="190."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="195."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="191."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="196."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="192."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="197."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="193."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="198."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="194."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="199."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="195."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="200."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="196."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="201."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="197."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="202."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="198."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="203."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="199."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="204."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="200."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="205."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="201."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay </span><span class="diff-chunk diff-chunk-removed">up to £10,000 </span><span class="diff-chunk diff-chunk-equal">at the Post Office </span><span class="diff-chunk diff-chunk-removed">without being charged using:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="206."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="202."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
-          <td class="diff-line-number" data-content="207."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay </span><span class="diff-chunk diff-chunk-equal">at the Post Office </span><span class="diff-chunk diff-chunk-inserted">by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="203."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="208."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="204."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">      &lt;li&gt;cheque (if accepted)&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="205."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">      &lt;li&gt;cash&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="206."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">      &lt;li&gt;debit card&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="207."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="208."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="209."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;&lt;a rel="external" href="http://www.postoffice.co.uk/branch-finder"&gt;Contact your local Post Office branch&lt;/a&gt; to check if you can pay by cheque.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="210."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="209."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="211."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="210."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="212."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="211."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="213."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="212."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="214."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="213."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="215."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="214."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="216."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="215."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="217."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="216."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="218."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="217."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="219."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="218."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="220."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="219."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="221."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="220."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="222."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="221."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="223."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="222."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="224."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="223."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="225."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="224."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="226."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="225."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="227."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="226."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="228."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="227."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="229."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="228."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="230."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="229."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="231."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="230."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="232."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return </span><span class="diff-chunk diff-chunk-removed">and wish to pay by cheque at the same time, please send your return and</span><span class="diff-chunk diff-chunk-equal"> payment to:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="231."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return </span><span class="diff-chunk diff-chunk-inserted">or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your</span><span class="diff-chunk diff-chunk-equal"> payment to:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="233."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="232."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="234."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="233."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="235."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="234."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="236."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
-          <td class="diff-line-number" data-content="235."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="237."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
-          <td class="diff-line-number" data-content="236."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="238."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
-          <td class="diff-line-number" data-content="237."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="239."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
-          <td class="diff-line-number" data-content="238."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="240."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
-          <td class="diff-line-number" data-content="239."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="241."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
-          <td class="diff-line-number" data-content="240."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="242."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="241."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="243."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="242."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="244."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="243."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="245."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-removed">you filed electronically but choose to pay by cheque, please send your payment, enclosing a payslip or quoting a &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; to avoid delay</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="244."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-inserted">you’re using the DX service send to:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="245."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="246."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="247."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="248."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="249."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;Rapid Data Capture Centre</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="250."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;DX725593</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="251."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;Bootle 9</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="252."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="253."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="254."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="255."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="246."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="256."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="247."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="257."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="248."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="258."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="249."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
-          <td class="diff-line-number" data-content="259."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="250."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
-          <td class="diff-line-number" data-content="260."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="251."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
-          <td class="diff-line-number" data-content="261."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="252."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="262."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="253."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="263."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="254."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="264."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="255."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="265."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="256."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="266."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="257."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="267."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="258."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="268."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="259."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="269."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="260."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="270."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="261."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="271."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="262."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="272."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="263."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="273."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="264."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
-          <td class="diff-line-number" data-content="274."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="265."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
-          <td class="diff-line-number" data-content="275."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="266."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
-          <td class="diff-line-number" data-content="276."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="267."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
-          <td class="diff-line-number" data-content="277."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="268."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
-          <td class="diff-line-number" data-content="278."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="269."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="279."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="270."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
-          <td class="diff-line-number" data-content="280."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="271."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="281."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="272."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
-          <td class="diff-line-number" data-content="282."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="273."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
-          <td class="diff-line-number" data-content="283."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="274."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
-          <td class="diff-line-number" data-content="284."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="275."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
-          <td class="diff-line-number" data-content="285."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="276."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
-          <td class="diff-line-number" data-content="286."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="277."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
-          <td class="diff-line-number" data-content="287."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="278."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
-          <td class="diff-line-number" data-content="288."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="279."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
-          <td class="diff-line-number" data-content="289."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="280."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
-          <td class="diff-line-number" data-content="290."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="281."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
-          <td class="diff-line-number" data-content="291."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="282."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
-          <td class="diff-line-number" data-content="292."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="283."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
-          <td class="diff-line-number" data-content="293."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="284."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
-          <td class="diff-line-number" data-content="294."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="285."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
-          <td class="diff-line-number" data-content="295."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="286."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
-          <td class="diff-line-number" data-content="296."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="287."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="297."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="288."></td>
-          <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
-          <td class="diff-line-number" data-content="298."></td>
-          <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="289."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-removed">'2016-07-27T10:49:59.000+01:00'</span></td>
-          <td class="diff-line-number" data-content="299."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-inserted">'2016-02-29T09:30:12.000+00:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="290."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
-          <td class="diff-line-number" data-content="300."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="291."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
-          <td class="diff-line-number" data-content="301."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="292."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-          <td class="diff-line-number" data-content="302."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="293."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
-          <td class="diff-line-number" data-content="303."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="294."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-          <td class="diff-line-number" data-content="304."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="295."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
-          <td class="diff-line-number" data-content="305."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="296."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="306."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
-        </tr>
-      </tbody>
-    </table>
+<div class="diff-checker">
+  <div class="diff-output">
+    <div class="diff-table-container" data-reactid="41">
+      <div class="diff-table-content" data-reactid="42">
+        <table class="diff-table" data-reactid="43">
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="1."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
+              <td class="diff-line-number" data-content="1."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="2."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
+              <td class="diff-line-number" data-content="2."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="3."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
+              <td class="diff-line-number" data-content="3."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="4."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
+              <td class="diff-line-number" data-content="4."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="5."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
+              <td class="diff-line-number" data-content="5."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="6."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
+              <td class="diff-line-number" data-content="6."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="7."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> </span><span class="diff-chunk diff-chunk-removed">Find out how</span><span class="diff-chunk diff-chunk-equal"> to pay your Stamp Duty Land Tax (SDLT) and the time it </span><span class="diff-chunk diff-chunk-removed">takes</span></td>
+              <td class="diff-line-number" data-content="7."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> </span><span class="diff-chunk diff-chunk-inserted">How</span><span class="diff-chunk diff-chunk-equal"> to pay your Stamp Duty Land Tax (SDLT) and the time it </span><span class="diff-chunk diff-chunk-inserted">takes for</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="8."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">  for payments</span><span class="diff-chunk diff-chunk-equal"> to reach HM Revenue and Customs (HMRC).</span></td>
+              <td class="diff-line-number" data-content="8."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">  payment</span><span class="diff-chunk diff-chunk-equal"> to reach HM Revenue and Customs (HMRC).</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="9."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
+              <td class="diff-line-number" data-content="9."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="10."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
+              <td class="diff-line-number" data-content="10."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="11."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="11."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="12."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
+              <td class="diff-line-number" data-content="12."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="13."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a </span><span class="diff-chunk diff-chunk-removed">rel="external" </span><span class="diff-chunk diff-chunk-equal">href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction </span><span class="diff-chunk diff-chunk-removed">Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="13."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a </span><span class="diff-chunk diff-chunk-equal">href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction </span><span class="diff-chunk diff-chunk-inserted">Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="14."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="14."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="15."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="15."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="16."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="16."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="17."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="17."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="18."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="18."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="19."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="19."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="20."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="20."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="21."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="21."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="22."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="22."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="23."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="23."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="24."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="24."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="25."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="25."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="26."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="26."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="27."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="27."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="28."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="28."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="29."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="29."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="30."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="30."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="31."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="31."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="32."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="32."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="33."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="33."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="34."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="34."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="35."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="35."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="36."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="36."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="37."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="37."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="38."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="38."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="39."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="39."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="40."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="40."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="41."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="41."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="42."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="42."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="43."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="43."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="44."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="44."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="45."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="45."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="46."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="46."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="47."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="47."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="48."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="48."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="49."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="49."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="50."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="50."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="51."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="51."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-chaps-and-bacs"&gt;Online</span><span class="diff-chunk diff-chunk-equal"> or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="52."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-chaps-bacs"&gt;Online</span><span class="diff-chunk diff-chunk-equal"> or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="52."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="53."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="53."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="54."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="54."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="55."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="55."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-chaps-and-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="56."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="56."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="57."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="57."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="58."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="58."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="59."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="59."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="60."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="60."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="61."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="61."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="62."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="62."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="63."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="63."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="64."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="64."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="65."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="65."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="66."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="66."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="67."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="67."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="68."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="68."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="69."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="69."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="70."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="70."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="71."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="71."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-chaps-and-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="72."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="72."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="73."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="73."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="74."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="74."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="75."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="75."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="76."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="76."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="77."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="77."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="78."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="78."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="79."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="79."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="80."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="80."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="81."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="81."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="82."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="82."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="83."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="83."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="84."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="84."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="85."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="85."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="86."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="86."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="87."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="87."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="88."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="88."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="89."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="89."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="90."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="90."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="91."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="91."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="92."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="92."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="93."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="93."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="94."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="94."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="95."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="95."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="96."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="96."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="97."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="97."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="98."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="98."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="99."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="99."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="100."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="100."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="101."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="101."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="102."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="102."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="103."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="103."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+              <td class="diff-line-number" data-content="104."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="104."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="105."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="105."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="106."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="106."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="107."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="107."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="108."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="108."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="109."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="109."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="110."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="110."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="111."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="111."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="112."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="112."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="113."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="113."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="114."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="114."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="115."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="115."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="116."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="116."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="117."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="117."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="118."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="118."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="119."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="119."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="120."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="120."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="121."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="121."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="122."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="122."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="123."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="123."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="124."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="124."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="125."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="125."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="126."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="126."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="127."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="127."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="128."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="128."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="129."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="129."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="130."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="130."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="131."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="131."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="132."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="132."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="133."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="133."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="134."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="134."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="135."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="135."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="136."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="136."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="137."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="137."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="138."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="138."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="139."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="139."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="140."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="140."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="141."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="141."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+              <td class="diff-line-number" data-content="142."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="142."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="143."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="143."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="144."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="144."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="145."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="145."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="146."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="146."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="147."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="147."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="148."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="148."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="149."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="149."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="150."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="150."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="151."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="151."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    Barclays Bank Plc</span></td>
+              <td class="diff-line-number" data-content="152."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    Barclays Bank Plc</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="152."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;1 Churchill Place</span></td>
+              <td class="diff-line-number" data-content="153."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;1 Churchill Place</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="153."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
+              <td class="diff-line-number" data-content="154."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="154."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;United Kingdom</span></td>
+              <td class="diff-line-number" data-content="155."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;United Kingdom</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="155."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-removed">5HP</span></td>
+              <td class="diff-line-number" data-content="156."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 </span><span class="diff-chunk diff-chunk-inserted">5HO</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="156."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="157."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="157."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="158."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="158."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="159."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="159."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="160."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="160."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="161."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="161."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="162."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="162."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="163."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="163."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-removed">&lt;p&gt;There is a fee for credit cards.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="164."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    </span><span class="diff-chunk diff-chunk-inserted">&lt;p&gt;You’ll pay a 1.5% fee if you use a credit card. The fee isn’t refundable.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="165."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="166."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="167."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;p&gt;You may be directed to use a &lt;a href="https://www.gov.uk/help/beta"&gt;beta&lt;/a&gt; service when you pay online. This is replacing BillPay.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="168."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="164."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="169."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="165."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="170."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="166."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="171."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="167."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="172."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="168."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="173."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="169."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="174."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="170."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="175."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="171."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to </span><span class="diff-chunk diff-chunk-removed">get around</span><span class="diff-chunk diff-chunk-equal"> this restriction.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="176."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to </span><span class="diff-chunk diff-chunk-inserted">circumvent</span><span class="diff-chunk diff-chunk-equal"> this restriction.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="172."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="177."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="173."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="178."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="174."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="179."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="175."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="180."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="176."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="181."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="177."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="182."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="178."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="183."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="179."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="184."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="180."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="185."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="181."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="186."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="182."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="187."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="183."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="188."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="184."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="189."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="185."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="190."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="186."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="191."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="187."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="192."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="188."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="193."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="189."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="194."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="190."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="195."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="191."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="196."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="192."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="197."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="193."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="198."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="194."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="199."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="195."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="200."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="196."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="201."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="197."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="202."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="198."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="203."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="199."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="204."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="200."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="205."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="201."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay </span><span class="diff-chunk diff-chunk-removed">up to £10,000 </span><span class="diff-chunk diff-chunk-equal">at the Post Office </span><span class="diff-chunk diff-chunk-removed">without being charged using:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="206."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="202."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
+              <td class="diff-line-number" data-content="207."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay </span><span class="diff-chunk diff-chunk-equal">at the Post Office </span><span class="diff-chunk diff-chunk-inserted">by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="203."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="208."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="204."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">      &lt;li&gt;cheque (if accepted)&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="205."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">      &lt;li&gt;cash&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="206."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">      &lt;li&gt;debit card&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="207."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="208."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="209."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;&lt;a rel="external" href="http://www.postoffice.co.uk/branch-finder"&gt;Contact your local Post Office branch&lt;/a&gt; to check if you can pay by cheque.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="210."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="209."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="211."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="210."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="212."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="211."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="213."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="212."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="214."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="213."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="215."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="214."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="216."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="215."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="217."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="216."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="218."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="217."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="219."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="218."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="220."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="219."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="221."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="220."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="222."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="221."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="223."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="222."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="224."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="223."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="225."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="224."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="226."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="225."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="227."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="226."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="228."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="227."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="229."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="228."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="230."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="229."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="231."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="230."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="232."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return </span><span class="diff-chunk diff-chunk-removed">and wish to pay by cheque at the same time, please send your return and</span><span class="diff-chunk diff-chunk-equal"> payment to:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="231."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return </span><span class="diff-chunk diff-chunk-inserted">or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your</span><span class="diff-chunk diff-chunk-equal"> payment to:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="233."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="232."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="234."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="233."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="235."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="234."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="236."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
+              <td class="diff-line-number" data-content="235."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="237."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
+              <td class="diff-line-number" data-content="236."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="238."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
+              <td class="diff-line-number" data-content="237."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="239."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
+              <td class="diff-line-number" data-content="238."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="240."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
+              <td class="diff-line-number" data-content="239."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="241."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
+              <td class="diff-line-number" data-content="240."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="242."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="241."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="243."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="242."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="244."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="243."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="245."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-removed">you filed electronically but choose to pay by cheque, please send your payment, enclosing a payslip or quoting a &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; to avoid delay</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="244."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-inserted">you’re using the DX service send to:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="245."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="246."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="247."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="248."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="249."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;Rapid Data Capture Centre</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="250."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;DX725593</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="251."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;Bootle 9</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="252."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="253."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="254."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="255."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="246."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="256."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="247."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="257."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="248."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="258."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="249."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
+              <td class="diff-line-number" data-content="259."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="250."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
+              <td class="diff-line-number" data-content="260."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="251."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
+              <td class="diff-line-number" data-content="261."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="252."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="262."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="253."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="263."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="254."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="264."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="255."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="265."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="256."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="266."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="257."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="267."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="258."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="268."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="259."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="269."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="260."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="270."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="261."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="271."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="262."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="272."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="263."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="273."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="264."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
+              <td class="diff-line-number" data-content="274."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="265."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
+              <td class="diff-line-number" data-content="275."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="266."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
+              <td class="diff-line-number" data-content="276."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="267."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
+              <td class="diff-line-number" data-content="277."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="268."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
+              <td class="diff-line-number" data-content="278."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="269."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="279."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="270."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
+              <td class="diff-line-number" data-content="280."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="271."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="281."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="272."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
+              <td class="diff-line-number" data-content="282."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="273."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
+              <td class="diff-line-number" data-content="283."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="274."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
+              <td class="diff-line-number" data-content="284."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="275."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
+              <td class="diff-line-number" data-content="285."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="276."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
+              <td class="diff-line-number" data-content="286."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="277."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
+              <td class="diff-line-number" data-content="287."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="278."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
+              <td class="diff-line-number" data-content="288."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="279."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
+              <td class="diff-line-number" data-content="289."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="280."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
+              <td class="diff-line-number" data-content="290."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="281."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
+              <td class="diff-line-number" data-content="291."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="282."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
+              <td class="diff-line-number" data-content="292."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="283."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
+              <td class="diff-line-number" data-content="293."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="284."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
+              <td class="diff-line-number" data-content="294."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="285."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
+              <td class="diff-line-number" data-content="295."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="286."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
+              <td class="diff-line-number" data-content="296."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="287."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="297."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="288."></td>
+              <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
+              <td class="diff-line-number" data-content="298."></td>
+              <td class="diff-line start end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="289."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-removed">'2016-07-27T10:49:59.000+01:00'</span></td>
+              <td class="diff-line-number" data-content="299."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-inserted">'2016-02-29T09:30:12.000+00:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="290."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
+              <td class="diff-line-number" data-content="300."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="291."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
+              <td class="diff-line-number" data-content="301."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="292."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+              <td class="diff-line-number" data-content="302."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="293."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
+              <td class="diff-line-number" data-content="303."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="294."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+              <td class="diff-line-number" data-content="304."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="295."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
+              <td class="diff-line-number" data-content="305."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="296."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="306."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-02T14:31:42.000+00:00'</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
 </div>

--- a/historical-frontend/v4-v3.html
+++ b/historical-frontend/v4-v3.html
@@ -4,7 +4,7 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
 ---
 
 {% include_relative _heading.html %}
-{% include_relative _select.html from="v4" to="v3" %}
+{% include_relative _compare.html from=4 to=3 %}
 
 <div class="diff-checker">
   <div class="diff-output">

--- a/historical-frontend/v4-v3.html
+++ b/historical-frontend/v4-v3.html
@@ -1545,7 +1545,7 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
             </tr>
             <tr class="diff-row">
               <td class="diff-line-number" data-content="245."></td>
-              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-removed">you filed electronically but choose to pay by cheque, please send your payment, enclosing a payslip or quoting a &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; to avoid delay</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-removed">you filed electronically but choose to pay by cheque, please send your payment, enclosing a payslip or quoting a &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; to avoid delay</span><span class="diff-chunk diff-chunk-equal"> to:&lt;/p&gt;</span></td>
               <td class="diff-line-number" data-content="240."></td>
               <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-inserted">you’re using the DX service send to:&lt;/p&gt;</span></td>
             </tr>
@@ -1613,7 +1613,7 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
               <td class="diff-line-number" data-content=""></td>
               <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
               <td class="diff-line-number" data-content="251."></td>
-              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque</span><span class="diff-chunk diff-chunk-equal"> to:&lt;/p&gt;</span></td>
             </tr>
             <tr class="diff-row">
               <td class="diff-line-number" data-content="246."></td>

--- a/historical-frontend/v4-v3.html
+++ b/historical-frontend/v4-v3.html
@@ -6,1932 +6,1936 @@ title: Comparing content of "Pay Stamp Duty Land Tax"
 {% include_relative _heading.html %}
 {% include_relative _select.html from="v4" to="v3" %}
 
-<div class="diff-table-container" data-reactid="41">
-  <div class="diff-table-content" data-reactid="42">
-    <table class="diff-table" data-reactid="43">
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="1."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
-          <td class="diff-line-number" data-content="1."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="2."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
-          <td class="diff-line-number" data-content="2."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="3."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
-          <td class="diff-line-number" data-content="3."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="4."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
-          <td class="diff-line-number" data-content="4."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="5."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
-          <td class="diff-line-number" data-content="5."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="6."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
-          <td class="diff-line-number" data-content="6."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="7."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> </span><span class="diff-chunk diff-chunk-removed">Find out how</span><span class="diff-chunk diff-chunk-equal"> to pay your Stamp Duty Land Tax (SDLT) and the time it </span><span class="diff-chunk diff-chunk-removed">takes</span></td>
-          <td class="diff-line-number" data-content="7."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> </span><span class="diff-chunk diff-chunk-inserted">How</span><span class="diff-chunk diff-chunk-equal"> to pay your Stamp Duty Land Tax (SDLT) and the time it </span><span class="diff-chunk diff-chunk-inserted">takes for</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="8."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">  for payments</span><span class="diff-chunk diff-chunk-equal"> to reach HM Revenue and Customs (HMRC).</span></td>
-          <td class="diff-line-number" data-content="8."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">  payment</span><span class="diff-chunk diff-chunk-equal"> to reach HM Revenue and Customs (HMRC).</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="9."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
-          <td class="diff-line-number" data-content="9."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="10."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
-          <td class="diff-line-number" data-content="10."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="11."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="11."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="12."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
-          <td class="diff-line-number" data-content="12."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="13."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a </span><span class="diff-chunk diff-chunk-removed">rel="external" </span><span class="diff-chunk diff-chunk-equal">href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction </span><span class="diff-chunk diff-chunk-removed">Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="13."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a </span><span class="diff-chunk diff-chunk-equal">href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction </span><span class="diff-chunk diff-chunk-inserted">Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="14."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="14."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="15."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="15."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="16."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="16."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="17."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="17."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="18."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="18."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="19."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="19."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="20."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="20."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="21."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="21."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="22."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="22."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="23."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="23."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="24."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="24."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-          <td class="diff-line-number" data-content="25."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="25."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="26."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="26."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="27."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="27."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="28."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="28."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="29."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="29."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="30."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="30."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="31."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="31."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="32."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="32."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="33."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="33."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="34."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="34."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="35."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="35."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="36."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="36."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="37."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="37."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="38."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="38."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="39."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="39."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="40."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="40."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="41."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="41."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="42."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="42."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="43."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="43."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="44."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="44."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="45."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="45."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="46."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="46."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="47."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="47."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="48."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="48."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="49."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="49."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="50."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="50."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="51."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="51."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-chaps-and-bacs"&gt;Online</span><span class="diff-chunk diff-chunk-equal"> or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="52."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-chaps-bacs"&gt;Online</span><span class="diff-chunk diff-chunk-equal"> or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="52."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="53."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="53."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="54."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="54."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="55."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="55."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-chaps-and-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="56."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="56."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="57."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="57."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="58."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="58."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="59."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="59."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="60."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="60."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="61."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="61."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="62."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="62."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="63."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="63."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="64."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="64."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="65."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="65."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="66."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="66."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="67."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="67."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="68."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="68."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="69."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="69."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="70."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="70."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="71."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="71."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-chaps-and-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="72."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="72."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="73."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="73."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="74."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="74."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="75."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="75."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="76."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="76."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="77."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="77."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="78."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="78."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="79."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="79."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="80."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="80."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="81."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="81."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="82."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="82."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="83."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="83."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="84."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="84."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="85."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="85."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
-          <td class="diff-line-number" data-content="86."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="86."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="87."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="87."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="88."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="88."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="89."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="89."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="90."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="90."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="91."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="91."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="92."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="92."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="93."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="93."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="94."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="94."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="95."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="95."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="96."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="96."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="97."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="97."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="98."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="98."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="99."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="99."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="100."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="100."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="101."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="101."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="102."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="102."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="103."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="103."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-          <td class="diff-line-number" data-content="104."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="104."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="105."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="105."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="106."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="106."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="107."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="107."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="108."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="108."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="109."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="109."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="110."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="110."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="111."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="111."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="112."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="112."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="113."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="113."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="114."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="114."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="115."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="115."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="116."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="116."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="117."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="117."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="118."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="118."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="119."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="119."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="120."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="120."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="121."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="121."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="122."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="122."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="123."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="123."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="124."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="124."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="125."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="125."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="126."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="126."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="127."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="127."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="128."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="128."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="129."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="129."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-          <td class="diff-line-number" data-content="130."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="130."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-          <td class="diff-line-number" data-content="131."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="131."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="132."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="132."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="133."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="133."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="134."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="134."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-          <td class="diff-line-number" data-content="135."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="135."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="136."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="136."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-          <td class="diff-line-number" data-content="137."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="137."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="138."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="138."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-          <td class="diff-line-number" data-content="139."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="139."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="140."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="140."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="141."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="141."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-          <td class="diff-line-number" data-content="142."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="142."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-          <td class="diff-line-number" data-content="143."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="143."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-          <td class="diff-line-number" data-content="144."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="144."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-          <td class="diff-line-number" data-content="145."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="145."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-          <td class="diff-line-number" data-content="146."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="146."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="147."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="147."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="148."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="148."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="149."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="149."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="150."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="150."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="151."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="151."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    Barclays Bank Plc</span></td>
-          <td class="diff-line-number" data-content="152."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    Barclays Bank Plc</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="152."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;1 Churchill Place</span></td>
-          <td class="diff-line-number" data-content="153."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;1 Churchill Place</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="153."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
-          <td class="diff-line-number" data-content="154."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="154."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;United Kingdom</span></td>
-          <td class="diff-line-number" data-content="155."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;United Kingdom</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="155."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 5HP</span></td>
-          <td class="diff-line-number" data-content="156."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 5HP</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="156."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="157."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="157."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="158."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="158."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="159."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="159."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="160."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="160."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="161."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="161."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="162."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="162."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="163."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="163."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;There is a fee for credit cards.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="164."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;There is a fee for credit cards.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="164."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="165."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="165."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="166."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="166."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="167."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="167."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="168."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="168."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="169."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="169."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="170."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="170."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="171."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="171."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to </span><span class="diff-chunk diff-chunk-removed">get around</span><span class="diff-chunk diff-chunk-equal"> this restriction.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="172."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to </span><span class="diff-chunk diff-chunk-inserted">circumvent</span><span class="diff-chunk diff-chunk-equal"> this restriction.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="172."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="173."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="173."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="174."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="174."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="175."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="175."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="176."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="176."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="177."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="177."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="178."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="178."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="179."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="179."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="180."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="180."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="181."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="181."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="182."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="182."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="183."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="183."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="184."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="184."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="185."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="185."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="186."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="186."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="187."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="187."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="188."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="188."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="189."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="189."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="190."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="190."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="191."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="191."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="192."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="192."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="193."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="193."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="194."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="194."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="195."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="195."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="196."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="196."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="197."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="197."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="198."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="198."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="199."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="199."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="200."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="200."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="201."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="201."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay </span><span class="diff-chunk diff-chunk-removed">up to £10,000 </span><span class="diff-chunk diff-chunk-equal">at the Post Office </span><span class="diff-chunk diff-chunk-removed">without being charged using:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="202."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="202."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
-          <td class="diff-line-number" data-content="203."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay </span><span class="diff-chunk diff-chunk-equal">at the Post Office </span><span class="diff-chunk diff-chunk-inserted">by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="203."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="204."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="204."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">      &lt;li&gt;cheque (if accepted)&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="205."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">      &lt;li&gt;cash&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="206."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">      &lt;li&gt;debit card&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="207."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="208."></td>
-          <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="209."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;&lt;a rel="external" href="http://www.postoffice.co.uk/branch-finder"&gt;Contact your local Post Office branch&lt;/a&gt; to check if you can pay by cheque.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="210."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="205."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="211."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="206."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="212."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="207."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="213."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-          <td class="diff-line-number" data-content="208."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="214."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="209."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="215."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-          <td class="diff-line-number" data-content="210."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="216."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-          <td class="diff-line-number" data-content="211."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="217."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="212."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="218."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="213."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="219."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="214."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="220."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="215."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="221."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="216."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="222."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
-          <td class="diff-line-number" data-content="217."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="223."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="218."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="224."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="219."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="225."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="220."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="226."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="221."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="227."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="222."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="228."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="223."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="229."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="224."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="230."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="225."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="231."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="226."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="232."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return </span><span class="diff-chunk diff-chunk-removed">and wish to pay by cheque at the same time, please send your return and</span><span class="diff-chunk diff-chunk-equal"> payment to:&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="227."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return </span><span class="diff-chunk diff-chunk-inserted">or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your</span><span class="diff-chunk diff-chunk-equal"> payment to:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="233."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="228."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="234."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="229."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="235."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="230."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="236."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
-          <td class="diff-line-number" data-content="231."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="237."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
-          <td class="diff-line-number" data-content="232."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="238."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
-          <td class="diff-line-number" data-content="233."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="239."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
-          <td class="diff-line-number" data-content="234."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="240."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
-          <td class="diff-line-number" data-content="235."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="241."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
-          <td class="diff-line-number" data-content="236."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="242."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="237."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="243."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="238."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="244."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="239."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="245."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-removed">you filed electronically but choose to pay by cheque, please send your payment, enclosing a payslip or quoting a &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; to avoid delay</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="240."></td>
-          <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-inserted">you’re using the DX service send to:&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="241."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="242."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="243."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="244."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="245."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;Rapid Data Capture Centre</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="246."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;DX725593</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="247."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;Bootle 9</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="248."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="249."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="250."></td>
-          <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content=""></td>
-          <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
-          <td class="diff-line-number" data-content="251."></td>
-          <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="246."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="252."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="247."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-          <td class="diff-line-number" data-content="253."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="248."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="254."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="249."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
-          <td class="diff-line-number" data-content="255."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="250."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
-          <td class="diff-line-number" data-content="256."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="251."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
-          <td class="diff-line-number" data-content="257."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="252."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-          <td class="diff-line-number" data-content="258."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="253."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="259."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="254."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="260."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="255."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-          <td class="diff-line-number" data-content="261."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="256."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="262."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="257."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="263."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="258."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="264."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="259."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="265."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="260."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="266."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="261."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-          <td class="diff-line-number" data-content="267."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="262."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-          <td class="diff-line-number" data-content="268."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="263."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-          <td class="diff-line-number" data-content="269."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="264."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
-          <td class="diff-line-number" data-content="270."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="265."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
-          <td class="diff-line-number" data-content="271."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="266."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
-          <td class="diff-line-number" data-content="272."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="267."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
-          <td class="diff-line-number" data-content="273."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="268."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
-          <td class="diff-line-number" data-content="274."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="269."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="275."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="270."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
-          <td class="diff-line-number" data-content="276."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="271."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="277."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="272."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
-          <td class="diff-line-number" data-content="278."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="273."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
-          <td class="diff-line-number" data-content="279."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="274."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
-          <td class="diff-line-number" data-content="280."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="275."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
-          <td class="diff-line-number" data-content="281."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="276."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
-          <td class="diff-line-number" data-content="282."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="277."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
-          <td class="diff-line-number" data-content="283."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="278."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
-          <td class="diff-line-number" data-content="284."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="279."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
-          <td class="diff-line-number" data-content="285."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="280."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
-          <td class="diff-line-number" data-content="286."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="281."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
-          <td class="diff-line-number" data-content="287."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="282."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
-          <td class="diff-line-number" data-content="288."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="283."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
-          <td class="diff-line-number" data-content="289."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="284."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
-          <td class="diff-line-number" data-content="290."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="285."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
-          <td class="diff-line-number" data-content="291."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="286."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
-          <td class="diff-line-number" data-content="292."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="287."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="293."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-for-change-context">
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="288."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
-          <td class="diff-line-number" data-content="294."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="289."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-removed">'2016-07-27T10:49:59.000+01:00'</span></td>
-          <td class="diff-line-number" data-content="295."></td>
-          <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-inserted">'2016-04-01T08:00:06.000+01:00'</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="290."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
-          <td class="diff-line-number" data-content="296."></td>
-          <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
-        </tr>
-      </tbody>
-      <tbody class="section-without-changes">
-        <tr class="spacer">
-          <td colspan="4">... <a href="#" class="expander">[+]</a></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="291."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
-          <td class="diff-line-number" data-content="297."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="292."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-          <td class="diff-line-number" data-content="298."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="293."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
-          <td class="diff-line-number" data-content="299."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="294."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-          <td class="diff-line-number" data-content="300."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="295."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
-          <td class="diff-line-number" data-content="301."></td>
-          <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
-        </tr>
-        <tr class="diff-row">
-          <td class="diff-line-number" data-content="296."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-          <td class="diff-line-number" data-content="302."></td>
-          <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
-        </tr>
-      </tbody>
-    </table>
+<div class="diff-checker">
+  <div class="diff-output">
+    <div class="diff-table-container" data-reactid="41">
+      <div class="diff-table-content" data-reactid="42">
+        <table class="diff-table" data-reactid="43">
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="1."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
+              <td class="diff-line-number" data-content="1."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>title:</strong> Pay Stamp Duty Land Tax</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="2."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
+              <td class="diff-line-number" data-content="2."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>locale:</strong> en</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="3."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
+              <td class="diff-line-number" data-content="3."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>need_ids:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="4."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
+              <td class="diff-line-number" data-content="4."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>-</strong> '102606'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="5."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
+              <td class="diff-line-number" data-content="5."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>publishing_app:</strong> whitehall</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="6."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
+              <td class="diff-line-number" data-content="6."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>redirects:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="7."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> </span><span class="diff-chunk diff-chunk-removed">Find out how</span><span class="diff-chunk diff-chunk-equal"> to pay your Stamp Duty Land Tax (SDLT) and the time it </span><span class="diff-chunk diff-chunk-removed">takes</span></td>
+              <td class="diff-line-number" data-content="7."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>description:</strong> </span><span class="diff-chunk diff-chunk-inserted">How</span><span class="diff-chunk diff-chunk-equal"> to pay your Stamp Duty Land Tax (SDLT) and the time it </span><span class="diff-chunk diff-chunk-inserted">takes for</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="8."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">  for payments</span><span class="diff-chunk diff-chunk-equal"> to reach HM Revenue and Customs (HMRC).</span></td>
+              <td class="diff-line-number" data-content="8."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">  payment</span><span class="diff-chunk diff-chunk-equal"> to reach HM Revenue and Customs (HMRC).</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="9."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
+              <td class="diff-line-number" data-content="9."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>details:</strong></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="10."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
+              <td class="diff-line-number" data-content="10."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>body:</strong> |</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="11."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="11."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">    &lt;div class="govspeak"&gt;&lt;h2 id="overview"&gt;Overview&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="12."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
+              <td class="diff-line-number" data-content="12."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="13."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a </span><span class="diff-chunk diff-chunk-removed">rel="external" </span><span class="diff-chunk diff-chunk-equal">href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction </span><span class="diff-chunk diff-chunk-removed">Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="13."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 April 2015 &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; no longer applies to land transactions in Scotland. These will be subject to &lt;a </span><span class="diff-chunk diff-chunk-equal">href="https://www.gov.uk/sdlt-scottish-transactions"&gt;Land and Buildings Transaction </span><span class="diff-chunk diff-chunk-inserted">Tax&lt;/a&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="14."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="14."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="15."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="15."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="16."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; is paid when property is bought or transferred in the UK.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="16."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="17."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="17."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="18."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payment of &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; shouldn’t be confused with paying either:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="18."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="19."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="19."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="20."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="20."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="21."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="21."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="22."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty"&gt;Stamp Duty&lt;/a&gt; on shares bought on a stock transfer form&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="22."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="23."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="23."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="24."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.gov.uk/pay-stamp-duty-reserve-tax"&gt;Stamp Duty Reserve Tax&lt;/a&gt; on the paperless purchase of shares&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="24."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+              <td class="diff-line-number" data-content="25."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="25."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="26."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;a rel="external" href="https://www.revenue.scot/land-buildings-transaction-tax"&gt;Land and Buildings Transaction Tax&lt;/a&gt; for transactions in Scotland&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="26."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="27."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="27."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="28."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="28."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="29."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payments and returns are due within 30 days of the ‘effective’ transaction date. This is usually the date of transaction completion but can be earlier, such as the date:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="29."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="30."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="30."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="31."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="31."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="32."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the purchaser is entitled to take possession of the property&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="32."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="33."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;the first rent payment is due&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="33."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="34."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;of substantial completion - where at least 90% of the payment (or other exchange) is made&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="34."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="35."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="35."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="36."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="36."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="37."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="how-much-time-to-allow"&gt;How much time to allow&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="37."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="38."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="38."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="39."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure you pay &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; by the deadline or you may have to pay a penalty and/or interest.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="39."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="40."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="40."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="41."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;The time you need to allow depends on how you pay.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="41."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="42."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="42."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="43."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="43."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="44."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="44."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="45."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="45."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="46."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Payment method&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="46."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="47."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Time allowance&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="47."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="48."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="48."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="49."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="49."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="50."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="50."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="51."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="51."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-chaps-and-bacs"&gt;Online</span><span class="diff-chunk diff-chunk-equal"> or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="52."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-chaps-bacs"&gt;Online</span><span class="diff-chunk diff-chunk-equal"> or Faster Payments&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="52."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="53."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="53."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="54."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="54."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="55."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="55."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-chaps-and-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="56."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-banking-chaps-bacs"&gt;CHAPS&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="56."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="57."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="57."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="58."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="58."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="59."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="59."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="60."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-your-bank-or-building-society"&gt;At your bank or building society&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="60."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="61."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="61."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="62."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="62."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="63."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="63."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="64."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#at-the-post-office"&gt;At the Post Office&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="64."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="65."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="65."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="66."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="66."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="67."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="67."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="68."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="68."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="69."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;Same or next day&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="69."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="70."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="70."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="71."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="71."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-removed">href="#bank-details-for-online-chaps-and-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="72."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a </span><span class="diff-chunk diff-chunk-inserted">href="#bank-details-for-online-or-telephone-banking-chaps-bacs"&gt;Bacs&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="72."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="73."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="73."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="74."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="74."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="75."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="75."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="76."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;&lt;a href="#post"&gt;By cheque through the post&lt;/a&gt;&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="76."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="77."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;3 working days&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="77."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="78."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="78."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="79."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="79."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="80."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="80."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="81."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="81."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="82."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="82."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="83."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure your payment reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the last working day before the deadline if it falls on a weekend or bank holiday (unless you’re paying by Faster Payments).&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="83."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="84."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="84."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="85."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="85."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
+              <td class="diff-line-number" data-content="86."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h2 id="ways-to-pay"&gt;Ways to pay&lt;/h2&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="86."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="87."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="87."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="88."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay by Faster Payments, CHAPS or Bacs to &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="88."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="89."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="89."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="90."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="bank-details-for-online-chaps-and-bacs"&gt;Bank details for online, CHAPS and Bacs&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="90."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="91."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="91."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="92."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="92."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="93."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="93."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="94."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="94."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="95."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Sort code&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="95."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="96."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="96."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="97."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="97."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="98."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="98."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="99."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="99."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="100."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="100."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="101."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="101."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="102."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;08 32 10&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="102."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="103."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;12001020&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="103."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+              <td class="diff-line-number" data-content="104."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="104."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="105."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="105."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="106."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="106."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="107."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="107."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="108."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="108."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="109."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="109."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="110."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character Unique Transaction Reference Number (&lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;). You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="110."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="111."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="111."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="112."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="112."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="113."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="113."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="114."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="114."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="115."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="115."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="116."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;It is recommended that you make separate payments for each unique &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. If you need to make a single payment to cover a number of transactions you should first contact &lt;a rel="external" href="http://www.hmrc.gov.uk/payingHMRC/shipley.htm"&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Shipley Accounts Office&lt;/a&gt; for further information. Please only contact this team for advice on CHAPS payments.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="116."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="117."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="117."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="118."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Payments by:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="118."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="119."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="119."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="120."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="120."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="121."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Faster Payments (online or telephone banking) usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; on the same or next day, including weekends and bank holidays&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="121."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="122."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;CHAPS usually reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; the same working day if you pay within your bank’s processing times&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="122."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="123."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;Bacs usually take 3 working days&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="123."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="124."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="124."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="125."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="125."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="126."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="overseas-payments"&gt;Overseas payments&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="126."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="127."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="127."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="128."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Use these details to pay from an overseas account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="128."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="129."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="129."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+              <td class="diff-line-number" data-content="130."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="130."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+              <td class="diff-line-number" data-content="131."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="131."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="132."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="132."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="133."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account number (IBAN)&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="133."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="134."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Bank identifier code (BIC)&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="134."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+              <td class="diff-line-number" data-content="135."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;th&gt;Account name&lt;/th&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="135."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="136."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="136."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+              <td class="diff-line-number" data-content="137."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/thead&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="137."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="138."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="138."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+              <td class="diff-line-number" data-content="139."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="139."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="140."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;GB03 BARC 2011 4783 9776 92&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="140."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="141."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;BARCGB22&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="141."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+              <td class="diff-line-number" data-content="142."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">          &lt;td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="142."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+              <td class="diff-line-number" data-content="143."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Shipley&lt;/td&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="143."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+              <td class="diff-line-number" data-content="144."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">        &lt;/tr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="144."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+              <td class="diff-line-number" data-content="145."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;/tbody&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="145."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+              <td class="diff-line-number" data-content="146."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/table&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="146."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="147."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="147."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="148."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you need to provide your bank with &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s banking address it is:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="148."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="149."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="149."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="150."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="150."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="151."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="151."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    Barclays Bank Plc</span></td>
+              <td class="diff-line-number" data-content="152."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    Barclays Bank Plc</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="152."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;1 Churchill Place</span></td>
+              <td class="diff-line-number" data-content="153."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;1 Churchill Place</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="153."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
+              <td class="diff-line-number" data-content="154."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;London</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="154."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;United Kingdom</span></td>
+              <td class="diff-line-number" data-content="155."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;United Kingdom</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="155."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 5HP</span></td>
+              <td class="diff-line-number" data-content="156."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;E14 5HP</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="156."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="157."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="157."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="158."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="158."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="159."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="159."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="160."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="by-debit-or-credit-card-online"&gt;By debit or credit card online&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="160."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="161."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="161."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="162."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can &lt;a rel="external" href="https://www.tax.service.gov.uk/pay-online/stamp-duty"&gt;pay online&lt;/a&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="162."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="163."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="163."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;There is a fee for credit cards.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="164."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;There is a fee for credit cards.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="164."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="165."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="165."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="166."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;From 1 January 2016, &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will limit the number of credit and debit card payments you can make to any single tax regime within a given period of time, so that only a reasonable number of payments can be made.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="166."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="167."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="167."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="168."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will determine what is reasonable by reference to payment card industry standards and guidance.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="168."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="169."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="169."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="170."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re unable to make full payment by credit/debit card you’ll have to use an alternative payment method.&lt;/p&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="170."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="171."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="171."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to </span><span class="diff-chunk diff-chunk-removed">get around</span><span class="diff-chunk diff-chunk-equal"> this restriction.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="172."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; may withdraw the facility to pay by credit/debit card from any customer attempting to </span><span class="diff-chunk diff-chunk-inserted">circumvent</span><span class="diff-chunk diff-chunk-equal"> this restriction.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="172."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="173."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="173."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="174."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="174."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="175."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="175."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="176."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="176."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="177."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="177."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="178."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="178."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="179."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="179."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="180."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, including on bank holidays and weekends.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="180."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="181."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="181."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="182."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-your-bank-or-building-society"&gt;At your bank or building society&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="182."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="183."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="183."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="184."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can make payment at your own branch by cheque or cash. You’ll need your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="184."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="185."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="185."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="186."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="186."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="187."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="187."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="188."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="188."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="189."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your own bank branch - or you’ll be charged for the service&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="189."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="190."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;use your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return or use software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="190."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="191."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;make cheques payable to ‘HM Revenue and Customs’ and write your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; on the front&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="191."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="192."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="192."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="193."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="193."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="194."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="194."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="195."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Your payment may be delayed if you use the wrong reference number.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="195."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="196."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="196."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="197."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="197."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="198."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it and not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account, if you pay between Monday and Friday.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="198."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="199."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="199."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="200."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="at-the-post-office"&gt;At the Post Office&lt;/h3&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="200."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="201."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="201."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay </span><span class="diff-chunk diff-chunk-removed">up to £10,000 </span><span class="diff-chunk diff-chunk-equal">at the Post Office </span><span class="diff-chunk diff-chunk-removed">without being charged using:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="202."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="202."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
+              <td class="diff-line-number" data-content="203."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You can pay </span><span class="diff-chunk diff-chunk-equal">at the Post Office </span><span class="diff-chunk diff-chunk-inserted">by cheque, cash or debit card without charge (subject to a maximum of £10,000).&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="203."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="204."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="204."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">      &lt;li&gt;cheque (if accepted)&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="205."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">      &lt;li&gt;cash&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="206."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">      &lt;li&gt;debit card&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="207."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="208."></td>
+              <td class="diff-line diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed"></span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="209."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-removed">    &lt;p&gt;&lt;a rel="external" href="http://www.postoffice.co.uk/branch-finder"&gt;Contact your local Post Office branch&lt;/a&gt; to check if you can pay by cheque.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-inserts"></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="210."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="205."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="211."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="206."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make sure that you either use:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="212."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="207."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="213."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+              <td class="diff-line-number" data-content="208."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="214."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="209."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;your &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; payslip if you completed a paper return, or you’ll be charged&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="215."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+              <td class="diff-line-number" data-content="210."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">      &lt;li&gt;software that requires a payslip that shows the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; of your submitted return&lt;/li&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="216."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+              <td class="diff-line-number" data-content="211."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/ul&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="217."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="212."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="218."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="213."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should make cheques payable to ‘Post Office Ltd’.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="219."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="214."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="220."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="215."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;&lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; will accept your payment on the date you make it if you pay between Monday and Friday, not the date it reaches &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s account.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="221."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="216."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="222."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
+              <td class="diff-line-number" data-content="217."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;h3 id="post"&gt;By cheque through the post&lt;/h3&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="223."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="218."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="224."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="219."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Make your cheque payable to ‘HM Revenue and Customs only’ followed by your 11-character &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt;. You’ll find this on your paper return or on your electronic SDLT5 certificate. If you are sending a cheque for more than one &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; you should send a schedule listing each &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; against each amount.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="225."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="220."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="226."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="221."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return you’ll need to complete the payslip (from the back of the return) and send this with your cheque.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="227."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="222."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="228."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="223."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;Don’t fold the cheque or fasten it to other papers.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="229."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="224."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="230."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="225."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You should allow 3 working days for your payment to reach &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="231."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="226."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="232."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return </span><span class="diff-chunk diff-chunk-removed">and wish to pay by cheque at the same time, please send your return and</span><span class="diff-chunk diff-chunk-equal"> payment to:&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="227."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you filed a paper return </span><span class="diff-chunk diff-chunk-inserted">or if you used &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;’s Stamp Duty Online product or commercial software which generates your &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; send your</span><span class="diff-chunk diff-chunk-equal"> payment to:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="233."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="228."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="234."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="229."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="235."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="230."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="236."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
+              <td class="diff-line-number" data-content="231."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; Stamp Taxes</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="237."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
+              <td class="diff-line-number" data-content="232."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Comben House</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="238."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
+              <td class="diff-line-number" data-content="233."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Farriers Way</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="239."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
+              <td class="diff-line-number" data-content="234."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Netherton</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="240."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
+              <td class="diff-line-number" data-content="235."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Merseyside</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="241."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
+              <td class="diff-line-number" data-content="236."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;L30 4RN</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="242."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="237."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="243."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="238."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="244."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="239."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="245."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-removed">you filed electronically but choose to pay by cheque, please send your payment, enclosing a payslip or quoting a &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; to avoid delay</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="240."></td>
+              <td class="diff-line start diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If </span><span class="diff-chunk diff-chunk-inserted">you’re using the DX service send to:&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="241."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="242."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="243."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="244."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt; &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="245."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;Rapid Data Capture Centre</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="246."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;DX725593</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="247."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;Bootle 9</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="248."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="249."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="250."></td>
+              <td class="diff-line diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content=""></td>
+              <td class="diff-line end diff-line-empty diff-line-modified diff-line-with-removes"></td>
+              <td class="diff-line-number" data-content="251."></td>
+              <td class="diff-line end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-inserted">    &lt;p&gt;If you use commercial software that asks you to use the &lt;abbr title="Unique Transaction Reference Number"&gt;UTRN&lt;/abbr&gt; from your &lt;abbr title="Stamp Duty Land Tax"&gt;SDLT&lt;/abbr&gt; payslip book then send your payslip and cheque</span><span class="diff-chunk diff-chunk-equal"> <strong>to:</strong>&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="246."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="252."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="247."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+              <td class="diff-line-number" data-content="253."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="address"&gt;&lt;div class="adr org fn"&gt;&lt;p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="248."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="254."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="249."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
+              <td class="diff-line-number" data-content="255."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    HM Revenue and Customs</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="250."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
+              <td class="diff-line-number" data-content="256."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;Direct</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="251."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
+              <td class="diff-line-number" data-content="257."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;BX5 5BD</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="252."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+              <td class="diff-line-number" data-content="258."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;br&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="253."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="259."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/p&gt;&lt;/div&gt;&lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="254."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="260."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="255."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+              <td class="diff-line-number" data-content="261."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;div class="call-to-action"&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="256."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="262."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;You don’t need to include a street name, city name or PO box with this address.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="257."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="263."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="258."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="264."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="259."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="265."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you have a reply envelope showing a different address (HM Revenue and Customs, Bradford, BD98 1YY), you can still use the envelope to post your cheque.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="260."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="266."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="261."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+              <td class="diff-line-number" data-content="267."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;p&gt;If you’re paying by post you can include a letter with your payment to request a receipt from &lt;abbr title="HM Revenue and Customs"&gt;HMRC&lt;/abbr&gt;.&lt;/p&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="262."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+              <td class="diff-line-number" data-content="268."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="263."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+              <td class="diff-line-number" data-content="269."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    &lt;/div&gt;</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="264."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
+              <td class="diff-line-number" data-content="270."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>change_history:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="265."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
+              <td class="diff-line-number" data-content="271."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-07-27T10:49:59.000+01:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="266."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
+              <td class="diff-line-number" data-content="272."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Section about paying by cheque through the post has been updated.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="267."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
+              <td class="diff-line-number" data-content="273."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-04-01T08:00:06.000+01:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="268."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
+              <td class="diff-line-number" data-content="274."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Credit card fees have changed.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="269."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="275."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2016-02-29T09:30:12.000+00:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="270."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
+              <td class="diff-line-number" data-content="276."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> Overseas payment details changed.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="271."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="277."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>- public_timestamp:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="272."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
+              <td class="diff-line-number" data-content="278."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>note:</strong> First published.</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="273."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
+              <td class="diff-line-number" data-content="279."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>emphasised_organisations:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="274."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
+              <td class="diff-line-number" data-content="280."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  - 6667cce2-e809-4e21-ae09-cb0bdc1ddda3</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="275."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
+              <td class="diff-line-number" data-content="281."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>related_mainstream_content:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="276."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
+              <td class="diff-line-number" data-content="282."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>political:</strong> false</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="277."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
+              <td class="diff-line-number" data-content="283."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>government:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="278."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
+              <td class="diff-line-number" data-content="284."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>title:</strong> 2010 to 2015 Conservative and Liberal Democrat coalition government</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="279."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
+              <td class="diff-line-number" data-content="285."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>slug:</strong> 2010-to-2015-conservative-and-liberal-democrat-coalition-government</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="280."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
+              <td class="diff-line-number" data-content="286."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>current:</strong> false</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="281."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
+              <td class="diff-line-number" data-content="287."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>tags:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="282."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
+              <td class="diff-line-number" data-content="288."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>browse_pages:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="283."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
+              <td class="diff-line-number" data-content="289."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>policies:</strong> []</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="284."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
+              <td class="diff-line-number" data-content="290."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    <strong>topics:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="285."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
+              <td class="diff-line-number" data-content="291."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - de905af9-0b79-4f36-bc12-703d79971e8b</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="286."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
+              <td class="diff-line-number" data-content="292."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">    - 3a4f2122-b5f7-42f8-8167-9a4a8fca6c92</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="287."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="293."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>first_public_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-for-change-context">
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="288."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
+              <td class="diff-line-number" data-content="294."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>document_type:</strong> detailed_guide</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="289."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-removes"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-removed">'2016-07-27T10:49:59.000+01:00'</span></td>
+              <td class="diff-line-number" data-content="295."></td>
+              <td class="diff-line start end diff-line-modified diff-line-with-inserts"><span class="diff-chunk diff-chunk-equal"><strong>public_updated_at:</strong> </span><span class="diff-chunk diff-chunk-inserted">'2016-04-01T08:00:06.000+01:00'</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="290."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
+              <td class="diff-line-number" data-content="296."></td>
+              <td class="diff-line start"><span class="diff-chunk diff-chunk-equal"><strong>rendering_app:</strong> government-frontend</span></td>
+            </tr>
+          </tbody>
+          <tbody class="section-without-changes">
+            <tr class="spacer">
+              <td colspan="4">... <a href="#" class="expander">[+]</a></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="291."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
+              <td class="diff-line-number" data-content="297."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>schema_name:</strong> detailed_guide</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="292."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+              <td class="diff-line-number" data-content="298."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>base_path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="293."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
+              <td class="diff-line-number" data-content="299."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>routes:</strong></span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="294."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+              <td class="diff-line-number" data-content="300."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal"><strong>- path:</strong> "/guidance/pay-stamp-duty-land-tax"</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="295."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
+              <td class="diff-line-number" data-content="301."></td>
+              <td class="diff-line"><span class="diff-chunk diff-chunk-equal">  <strong>type:</strong> exact</span></td>
+            </tr>
+            <tr class="diff-row">
+              <td class="diff-line-number" data-content="296."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+              <td class="diff-line-number" data-content="302."></td>
+              <td class="diff-line end"><span class="diff-chunk diff-chunk-equal"><strong>first_published_at:</strong> '2015-12-30T14:31:42.000+00:00'</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
This:

- adds a breadcrumb to take you to the current document
- changes the "Choose" copy to be "Updates"
- wraps all the diffs in wrapper elements so styles are correctly displayed

And actually a bunch of other stuff like
- New compare navbar
- Change links on the choose page
- Help text