### PR TITLE
Change title 'sandwich' text

### DIFF
--- a/_includes/_stampduty_title.html
+++ b/_includes/_stampduty_title.html
@@ -2,7 +2,7 @@
   <div class="column-two-thirds">
     <div class="govuk-title length-long">
       {% if page.diff %}
-      <p class="title-contrast history-colour">You're viewing an update of</p>
+      <p class="title-contrast history-colour">You're viewing the edit history of</p>
       {% elsif page.version != 'current' %}
       <p class="title-contrast history-colour">You're viewing an old version of</p>
       {% else %}
@@ -11,7 +11,7 @@
       <h1>{{ page.title }}</h1>
       {% if page.version != 'current' or page.diff %}
       <p class="title-contrast history-colour">
-        published on {{ include.published_date | date: '%-d %B %Y' }}
+        this update was made on {{ include.published_date | date: '%-d %B %Y' }}
       </p>
       {% endif %}
     </div>

--- a/rates-and-thresholds-for-employers-2017-to-2018/_title.html
+++ b/rates-and-thresholds-for-employers-2017-to-2018/_title.html
@@ -2,7 +2,7 @@
   <div class="column-two-thirds">
     <div class="govuk-title length-long">
       {% if page.diff %}
-      <p class="title-contrast history-colour">You're viewing an update of</p>
+      <p class="title-contrast history-colour">You're viewing the edit history of</p>
       {% elsif page.version != 'current' %}
       <p class="title-contrast history-colour">You're viewing an old version of</p>
       {% endif %}
@@ -10,7 +10,7 @@
       <h1>{{ page.title }}</h1>
       {% if page.version != 'current' or page.diff %}
       <p class="title-contrast history-colour">
-        published on {{ include.published_date | date: '%-d %B %Y' }}
+        this update was made on {{ include.published_date | date: '%-d %B %Y' }}
       </p>
       {% endif %}
     </div>

--- a/self-employed-national-insurance-rates/_title.html
+++ b/self-employed-national-insurance-rates/_title.html
@@ -2,14 +2,14 @@
   <div class="column-two-thirds">
     <div class="govuk-title length-average">
       {% if page.diff %}
-      <p class="title-contrast history-colour">You're viewing an update of</p>
+      <p class="title-contrast history-colour">You're viewing the edit history of</p>
       {% elsif page.version != 'current' %}
       <p class="title-contrast history-colour">You're viewing an old version of</p>
       {% endif %}
       <h1>{{ page.title }}</h1>
       {% if page.version != 'current' or page.diff %}
       <p class="title-contrast history-colour">
-        published on {{ include.published_date | date: '%-d %B %Y' }}
+        this update was made on {{ include.published_date | date: '%-d %B %Y' }}
       </p>
       {% endif %}
     </div>


### PR DESCRIPTION
Three commits to update the red text around the page title on old versions of pages.

##Changed
You're viewing an update of

##To
You're viewing the edit history of

##Reason
'An update of' doesn't really make sense - this introduces a new term, 'edit history', but I'd like to see how that tests.

--

##Changed
published on

##To
this update was made on

##Reason
Gives context to the date. 'Published on' is ambiguous as could refer to the content as a whole, ie look like it's the 'first published' date.