### PR TITLE
Edit National Insurance body content (table)

### DIFF
--- a/self-employed-national-insurance-rates/_title.html
+++ b/self-employed-national-insurance-rates/_title.html
@@ -2,14 +2,14 @@
   <div class="column-two-thirds">
     <div class="govuk-title length-average">
       {% if page.diff %}
-      <p class="title-contrast history-colour">You're viewing an update of</p>
+      <p class="title-contrast history-colour">You're viewing the edit history of</p>
       {% elsif page.version != 'current' %}
       <p class="title-contrast history-colour">You're viewing an old version of</p>
       {% endif %}
       <h1>{{ page.title }}</h1>
       {% if page.version != 'current' or page.diff %}
       <p class="title-contrast history-colour">
-        published on {{ include.published_date | date: '%-d %B %Y' }}
+        this update was made on {{ include.published_date | date: '%-d %B %Y' }}
       </p>
       {% endif %}
     </div>

--- a/self-employed-national-insurance-rates/v1.html
+++ b/self-employed-national-insurance-rates/v1.html
@@ -40,7 +40,7 @@ version: 1
     </tr>
     <tr>
       <td>Class 4</td>
-      <td>9% on profits between £8,060 and £42,385<br>2% on profits over £42,385</td>
+      <td><strong>9% band: </strong>9% on profits between £8,060 and £42,385<br><strong>2% band: </strong>2% on profits over £42,385</td>
     </tr>
   </tbody>
 </table>

--- a/self-employed-national-insurance-rates/v2-diff.html
+++ b/self-employed-national-insurance-rates/v2-diff.html
@@ -139,6 +139,9 @@ Class
 4
 </td>
 <td>
+<strong>
+9% band: 
+</strong>
 9%
 on
 profits
@@ -147,6 +150,9 @@ between
 and
 £42,385
 <br>
+<strong>
+2% band: 
+</strong>
 2%
 on
 profits

--- a/self-employed-national-insurance-rates/v2.html
+++ b/self-employed-national-insurance-rates/v2.html
@@ -40,7 +40,7 @@ version: 2
     </tr>
     <tr>
       <td>Class 4</td>
-      <td>9% on profits between £8,060 and £42,385<br>2% on profits over £42,385</td>
+      <td><strong>9% band: </strong>9% on profits between £8,060 and £42,385<br><strong>2% band: </strong>2% on profits over £42,385</td>
     </tr>
   </tbody>
 </table>

--- a/self-employed-national-insurance-rates/v3-diff.html
+++ b/self-employed-national-insurance-rates/v3-diff.html
@@ -143,6 +143,9 @@ Class
 4
 </td>
 <td>
+<strong>
+9% band: 
+</strong>
 9%
 on
 profits
@@ -154,6 +157,9 @@ and
 <ins class="diff-chg">£43,000
 </ins>
 <br>
+<strong>
+2% band: 
+</strong>
 2%
 on
 profits

--- a/self-employed-national-insurance-rates/v3.html
+++ b/self-employed-national-insurance-rates/v3.html
@@ -40,7 +40,7 @@ version: 3
     </tr>
     <tr>
       <td>Class 4</td>
-      <td>9% on profits between £8,060 and £43,000<br>2% on profits over £43,000</td>
+      <td><strong>9% band: </strong>9% on profits between £8,060 and £43,000<br><strong>2% band: </strong>2% on profits over £43,000</td>
     </tr>
   </tbody>
 </table>

--- a/self-employed-national-insurance-rates/v4-diff.html
+++ b/self-employed-national-insurance-rates/v4-diff.html
@@ -152,6 +152,9 @@ Class
 4
 </td>
 <td>
+<strong>
+9% band: 
+</strong>
 9%
 on
 profits
@@ -166,6 +169,9 @@ and
 <ins class="diff-chg">£45,000
 </ins>
 <br>
+<strong>
+2% band: 
+</strong>
 2%
 on
 profits


### PR DESCRIPTION
6 commits to change the National Insurance body content slightly. This is to make the task easier so users tell us more about the content history functionality rather than getting bogged down in the actual task.

> There's also a 7th commit to change the sandwich text around the title to make more sense, as done in PR #42 for the other prototype pages.

I've added two bolded labels to the 'How much you pay' table, reading '9% band' and '2% band'.

We speak of different tax 'bands' in the task description, but this term isn't used on the page.

It occurred to us that it would be simpler to update the page so that it mentioned them rather than find another way of referring to tax bands.

